### PR TITLE
Fix/UI overlap

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -33,3 +33,74 @@ body{margin:0;font-family:Inter,system-ui,Segoe UI,Arial,Helvetica,sans-serif;co
 .section-title{font-weight:700;margin:8px 0 6px 0;color:#0f172a}
 .btn-link{background:none;border:none;color:var(--liberty-navy);cursor:pointer;text-decoration:underline;padding:0}
 .footer{max-width:1200px;margin:12px auto 32px;padding:0 16px;color:#64748b;font-size:12px}
+
+/* ==== Layout: two-column container ==== */
+.container {
+  display: grid;
+  grid-template-columns: 320px minmax(0, 1fr); /* left rail fixed, right flexible */
+  gap: 16px;               /* a bit more breathing room */
+  align-items: start;      /* keep cards from stretching vertically */
+}
+
+/* Ensure grid children can shrink instead of overflowing their cells */
+.container > * { min-width: 0; }
+
+/* Left column “stack” */
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  position: relative;
+  z-index: 2;              /* sit above, just in case */
+  min-width: 0;
+}
+
+/* Generic card wrapper */
+.card {
+  background: #fff;
+  border: 1px solid #E5E7EB;
+  border-radius: 16px;
+  padding: 16px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.06);
+  min-width: 0;            /* prevent overflow in grid cells */
+  overflow: hidden;        /* stop charts/contents from spilling out */
+}
+
+/* Two-up grids used for inputs and totals */
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  min-width: 0;
+}
+
+/* Inputs: keep labels & fields tidy and non-overflowing */
+.input-row {
+  display: grid;
+  grid-template-columns: 1fr 120px;
+  gap: 8px;
+  align-items: center;
+  min-width: 0;
+}
+.input-row > label {
+  font-size: 12px;
+  color: #6B7280;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis; /* don’t push layout if label is long */
+}
+.input-row > input {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* Vertical KPI stack on the right */
+.kpi-vertical {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+}
+
+/* Optional: if you want to belt-and-suspenders the whole app */
+.grid > * { min-width: 0; } /* safe guard if you use other .grid blocks */

--- a/src/styles.css
+++ b/src/styles.css
@@ -118,3 +118,27 @@ body{margin:0;font-family:Inter,system-ui,Segoe UI,Arial,Helvetica,sans-serif;co
 .stack .grid-2 .input-row > input {
   width: 100%;
 }
+
+
+/* === Left rail: give it a little more room + breathing space between columns === */
+.container {
+  grid-template-columns: 360px minmax(0, 1fr); /* was 320px */
+  gap: 24px;                                    /* was 16px */
+  padding: 0 24px;                               /* a touch more side padding */
+}
+
+/* === KPI/Expense labels: wrap instead of cutting off === */
+.stack .grid-2 .input-row > label {
+  display: block;             /* ensures wrapping takes effect */
+  white-space: normal;        /* allow multi-line */
+  overflow-wrap: anywhere;    /* break long phrases if needed */
+  line-height: 1.2;
+  font-size: 12px;            /* slightly smaller to fit nicely */
+  margin-bottom: 4px;         /* space above the input */
+}
+
+/* Inputs: fill the available column width cleanly */
+.stack .grid-2 .input-row > input {
+  width: 100%;
+  min-width: 0;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -142,3 +142,17 @@ body{margin:0;font-family:Inter,system-ui,Segoe UI,Arial,Helvetica,sans-serif;co
   width: 100%;
   min-width: 0;
 }
+
+/* Limit dropdown width in the left rail (Quick Inputs) */
+.stack select {
+  width: auto;          /* size to content */
+  max-width: 160px;     /* cap so it never stretches awkwardly */
+  min-width: 110px;     /* keep it tappable */
+}
+
+/* If ScenarioSelector renders inside .input-row, this keeps it neat */
+.stack .input-row select {
+  width: auto;
+  max-width: 160px;
+  min-width: 110px;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -104,3 +104,17 @@ body{margin:0;font-family:Inter,system-ui,Segoe UI,Arial,Helvetica,sans-serif;co
 
 /* Optional: if you want to belt-and-suspenders the whole app */
 .grid > * { min-width: 0; } /* safe guard if you use other .grid blocks */
+
+/* In the left rail's grid-2, stack label above input per field */
+.stack .grid-2 .input-row {
+  grid-template-columns: 1fr;   /* label above input */
+}
+
+.stack .grid-2 .input-row > label {
+  margin-bottom: 4px;
+  white-space: normal;
+}
+
+.stack .grid-2 .input-row > input {
+  width: 100%;
+}


### PR DESCRIPTION
fix(ui): cap Scenario dropdown width in left rail

- Restrict selects in Quick Inputs to auto width with sensible min/max
- Prevents Scenario selector from stretching to column width
