### PR TITLE
Fix form element accessibility in DebugSidebar

### DIFF
--- a/src/components/DebugSystem/DebugSidebar.tsx
+++ b/src/components/DebugSystem/DebugSidebar.tsx
@@ -324,6 +324,8 @@ export default function DebugSidebar(props: DebugSidebarProps) {
                     ...thresholds,
                     cprGreen: parseFloat(e.target.value) || 0
                   })}
+                  placeholder="15.0"
+                  aria-label="Cost per Return Green threshold"
                   style={inputStyle}
                 />
               </div>
@@ -337,6 +339,8 @@ export default function DebugSidebar(props: DebugSidebarProps) {
                     ...thresholds,
                     cprYellow: parseFloat(e.target.value) || 0
                   })}
+                  placeholder="20.0"
+                  aria-label="Cost per Return Yellow threshold"
                   style={inputStyle}
                 />
               </div>
@@ -350,6 +354,8 @@ export default function DebugSidebar(props: DebugSidebarProps) {
                     ...thresholds,
                     nimGreen: parseFloat(e.target.value) || 0
                   })}
+                  placeholder="25.0"
+                  aria-label="Net Income Margin Green threshold"
                   style={inputStyle}
                 />
               </div>
@@ -363,6 +369,8 @@ export default function DebugSidebar(props: DebugSidebarProps) {
                     ...thresholds,
                     nimYellow: parseFloat(e.target.value) || 0
                   })}
+                  placeholder="15.0"
+                  aria-label="Net Income Margin Yellow threshold"
                   style={inputStyle}
                 />
               </div>
@@ -376,6 +384,8 @@ export default function DebugSidebar(props: DebugSidebarProps) {
                     ...thresholds,
                     netIncomeWarn: parseFloat(e.target.value) || 0
                   })}
+                  placeholder="-5000"
+                  aria-label="Net Income Warning threshold"
                   style={inputStyle}
                 />
                 <div style={{ fontSize: 9, color: '#9ca3af', marginTop: 2 }}>


### PR DESCRIPTION
# Pull Request

## 📋 Description
Resolves an accessibility error in `src/components/DebugSystem/DebugSidebar.tsx` where input elements in the KPI thresholds section lacked proper labels. `placeholder` and `aria-label` attributes have been added to these inputs to improve accessibility and address linting warnings.

## 🔗 Related Issues
Closes #<!-- issue number -->

## 🧪 Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] 🧹 Code refactoring
- [ ] 🔧 Configuration/build changes

## 🧮 Calculation Changes
- [x] No calculation changes
- [ ] Dual-entry field calculations modified
- [ ] KPI calculations modified  
- [ ] Growth projection calculations modified
- [ ] Regional calculation differences (US/CA) modified
- [ ] Preset scenario calculations modified

**Calculation Testing:**
- [ ] Verified with existing test scenarios
- [ ] Added new test cases for edge cases
- [ ] Confirmed mathematical accuracy
- [ ] Tested dual-entry synchronization

## 🎯 Testing Checklist

### ✅ Automated Testing
- [x] All existing automated tests pass
- [ ] New tests added for new functionality
- [ ] Calculation tests updated (if applicable)
- [x] Build completes successfully
- [ ] Bundle size within acceptable limits

### 🖱️ Manual Testing - Core Functionality
- [ ] **Wizard Flow**: Complete wizard journey (Welcome → Inputs → Review → Dashboard)
- [ ] **Regional Testing**: Tested both US and CA regions
- [ ] **Dual-Entry**: Verified percentage ↔ dollar synchronization works
- [ ] **Calculations**: Spot-checked KPI calculations for accuracy
- [ ] **Presets**: Tested Good/Better/Best preset application
- [x] **Debug Panel**: Verified debug functionality works (specifically the KPI thresholds inputs)
- [ ] **Data Persistence**: Confirmed data survives page refresh

### 📱 Mobile/Responsive Testing
- [ ] **Mobile Layout**: Tested on mobile device (iOS/Android)
- [ ] **Tablet Layout**: Tested on tablet device
- [ ] **Touch Interactions**: All buttons/inputs work on touch devices
- [ ] **Keyboard Behavior**: Mobile keyboard doesn't obscure inputs
- [ ] **Orientation**: Works in both portrait and landscape

### 🌐 Browser Compatibility
- [x] **Chrome**: Tested and working
- [ ] **Firefox**: Tested and working
- [ ] **Safari**: Tested and working (if available)
- [ ] **Edge**: Tested and working (if available)
- [ ] **Mobile Browsers**: Tested on mobile Chrome/Safari

### 🔍 Edge Case Testing
- [ ] **Invalid Inputs**: Tested with invalid/edge case data
- [ ] **Zero Values**: Tested with zero percentages and dollar amounts
- [ ] **Maximum Values**: Tested with 100% and large numbers
- [ ] **Negative Growth**: Tested with negative growth scenarios
- [ ] **Empty States**: Tested with empty/default data

### ⚡ Performance Testing
- [ ] **Load Time**: Initial load time acceptable
- [ ] **Responsiveness**: UI interactions respond quickly
- [ ] **Memory Usage**: No obvious memory leaks
- [x] **Console**: No errors or warnings in browser console (specifically, the reported accessibility error is resolved)

## 📊 Test Results Summary
**Tested Scenarios:**
- Verified that the input fields in the Debug Sidebar's KPI thresholds section now display placeholders.
- Confirmed that the accessibility error reported in the console is no longer present.
- Ensured existing functionality of the debug inputs remains unchanged.

**Issues Found & Resolved:**
- The original accessibility error regarding missing labels/placeholders for form elements in `DebugSidebar.tsx` was resolved by adding `placeholder` and `aria-label` attributes.

**Known Limitations:**
- None.

## 📸 Screenshots/Videos
<!-- Add screenshots or videos demonstrating the changes -->

## 🚨 Breaking Changes
- [x] No breaking changes
- [ ] Breaking changes (describe below):

## 📝 Additional Notes
This change specifically targets an accessibility linting error, improving the user experience for screen reader users and adhering to form element best practices.

## 🤖 AI Code Review Section
### Questions for @codex:
- [x] **Code Quality Review:** @codex Please review this code for potential bugs, improvements, and best practices
- [x] **Performance Analysis:** @codex Any performance implications I should be aware of?
- [x] **Testing Recommendations:** @codex What additional test scenarios would you recommend?
- [ ] **Security Review:** @codex Any security considerations for these changes?

### AI-Specific Context:
**Change Type:** Bug fix
**Complexity:** Simple
**Risk Level:** Low

**Specific Areas for AI Focus:**
- [ ] Calculation logic accuracy
- [ ] React hooks usage
- [x] TypeScript type safety
- [x] Mobile responsiveness
- [ ] Error handling
- [ ] Performance optimization

## 👀 Human Reviewer Checklist
- [ ] Code follows project standards
- [ ] Changes are well documented
- [ ] Tests are comprehensive
- [ ] No security concerns
- [ ] Performance impact acceptable
- [ ] Mobile compatibility verified
- [ ] AI feedback addressed

---

## 🚀 Pre-Deployment Verification
- [ ] All automated tests pass in CI
- [ ] Manual testing checklist completed
- [ ] No console errors in production build
- [ ] Bundle size impact acceptable
- [ ] Ready for production deployment

---
<a href="https://cursor.com/background-agent?bcId=bc-eb0eddcc-d904-4ea5-ad88-ff5d21efe76d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eb0eddcc-d904-4ea5-ad88-ff5d21efe76d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

