### PR TITLE
fix(existing-store): source dictionary labels for prior-year ui

### DIFF
--- a/docs/expedition-log/EX-0003_field-dictionary.md
+++ b/docs/expedition-log/EX-0003_field-dictionary.md
@@ -1,0 +1,43 @@
+# EX-0003 Field Dictionary
+
+## Terrain
+- Centralized field metadata drives both prior-year normalization and income-driver goal forms through a single dictionary of keys, labels, validators, and derivations.【F:src/app/existing-store/shared/fields.dictionary.ts†L1-L197】
+
+## Artifacts
+- Dictionary rows inform schema selection and reactive control generation inside the income-drivers component.【F:src/app/components/income-drivers/income-drivers.component.ts†L46-L119】【F:src/app/components/income-drivers/income-drivers.component.ts†L227-L358】
+- Prior-year performance surface renders input labels and summary metrics straight from the dictionary, eliminating hard-coded copy.【F:src/app/components/prior-year-performance/prior-year-performance.component.ts†L42-L192】
+- Goals schema references the same keys by mode × region × store type to gate visibility and rules.【F:src/app/existing-store/income-drivers/goals.config.ts†L1-L134】
+
+## Fault Lines
+- Prior-year discount and other-income overrides are still surfaced through injected metrics rather than explicit fields, limiting alias flexibility for Canadian workflows.【F:src/app/components/income-drivers/income-drivers.component.ts†L264-L283】
+
+## Hypotheses
+- Extending the dictionary with prior-year discount/other-income inputs will align Angular parity with the React baseline once API payloads land.
+
+## Evidence
+| Field | Label | Type | Derive From | Validators | Usage |
+|-------|-------|------|-------------|------------|--------|
+| `avgNetFee` | Average Net Fee | money | — | required, min 50, max 500, step 1 | Schema-driven builder seeds and validates control.【F:src/app/existing-store/shared/fields.dictionary.ts†L44-L50】【F:src/app/components/income-drivers/income-drivers.component.ts†L227-L257】 |
+| `taxPrepReturns` | Tax Prep Returns | number | — | required, min 100, max 10000, step 1 | Drives gross-fee derivations inside the reactive form.【F:src/app/existing-store/shared/fields.dictionary.ts†L52-L58】【F:src/app/components/income-drivers/income-drivers.component.ts†L227-L257】【F:src/app/components/income-drivers/income-drivers.component.ts†L419-L434】 |
+| `taxRushReturns` | TaxRush Returns | number | — | min 0, max 10000, step 1 | Feeds TaxRush share and gross-fee calculations when enabled.【F:src/app/existing-store/shared/fields.dictionary.ts†L60-L66】【F:src/app/components/income-drivers/income-drivers.component.ts†L419-L438】 |
+| `taxRushPercentage` | TaxRush % of Returns | percent | `taxRushReturns`, `taxPrepReturns` | min 0, max 100, step 0.1 | Derived control showing share of returns in TaxRush scenarios.【F:src/app/existing-store/shared/fields.dictionary.ts†L68-L75】【F:src/app/components/income-drivers/income-drivers.component.ts†L419-L438】 |
+| `taxRushFee` | TaxRush Average Net Fee | money | — | min 0, max 500, step 1 | User-supplied average fee for TaxRush calculations.【F:src/app/existing-store/shared/fields.dictionary.ts†L77-L83】【F:src/app/components/income-drivers/income-drivers.component.ts†L427-L433】 |
+| `grossTaxPrepFees` | Gross Tax Prep Fees | money | `avgNetFee`, `taxPrepReturns` | — | Auto-calculated gross revenue baseline for goals.【F:src/app/existing-store/shared/fields.dictionary.ts†L85-L91】【F:src/app/components/income-drivers/income-drivers.component.ts†L419-L423】 |
+| `grossTaxRushFees` | Gross TaxRush Fees | money | `taxRushReturns`, `taxRushFee`, `avgNetFee`, `taxPrepReturns` | — | Derived TaxRush gross earnings including fallback to avg fee.【F:src/app/existing-store/shared/fields.dictionary.ts†L93-L99】【F:src/app/components/income-drivers/income-drivers.component.ts†L427-L434】 |
+| `discountsAmt` | Customer Discounts ($) | money | `grossTaxPrepFees`, `discountsPct` | — | Locked behind derivation to mirror percent-based adjustments.【F:src/app/existing-store/shared/fields.dictionary.ts†L101-L107】【F:src/app/components/income-drivers/income-drivers.component.ts†L422-L426】 |
+| `discountsPct` | Customer Discounts (%) | percent | — | min 0, max 100, step 0.1 | Manual percentage input mirrored by derived dollar amount and defaulted to 3%.【F:src/app/existing-store/shared/fields.dictionary.ts†L109-L115】【F:src/app/components/income-drivers/income-drivers.component.ts†L286-L304】【F:src/app/components/income-drivers/income-drivers.component.ts†L422-L424】 |
+| `netTaxPrepFees` | Net Tax Prep Fees | money | `grossTaxPrepFees`, `discountsAmt` | — | Derived net revenue after discounts for downstream expense heuristics.【F:src/app/existing-store/shared/fields.dictionary.ts†L117-L123】【F:src/app/components/income-drivers/income-drivers.component.ts†L422-L426】 |
+| `otherIncome` | Other Income | money | — | min 0, step 1 | Optional revenue streams toggled per schema rules.【F:src/app/existing-store/shared/fields.dictionary.ts†L125-L131】【F:src/app/existing-store/income-drivers/goals.config.ts†L10-L109】 |
+| `totalExpenses` | Total Expenses | money | `grossTaxPrepFees` | — | Auto-fills to 76% benchmark for projections.【F:src/app/existing-store/shared/fields.dictionary.ts†L133-L139】【F:src/app/components/income-drivers/income-drivers.component.ts†L435-L436】 |
+| `lastYearGrossFees` | Prior-Year Gross Fees | money | — | min 0, step 1 | Seeds prior-year revenue alignment for existing mode.【F:src/app/existing-store/shared/fields.dictionary.ts†L141-L149】【F:src/app/components/income-drivers/income-drivers.component.ts†L264-L283】 |
+| `lastYearExpenses` | Prior-Year Expenses | money | — | min 0, step 1 | Populates baseline expenses for comparisons.【F:src/app/existing-store/shared/fields.dictionary.ts†L150-L156】【F:src/app/components/income-drivers/income-drivers.component.ts†L264-L283】 |
+| `lastYearReturns` | Prior-Year Returns | number | — | min 0, max 10000, step 1 | Captures prior-year return volume for growth deltas.【F:src/app/existing-store/shared/fields.dictionary.ts†L158-L164】【F:src/app/components/income-drivers/income-drivers.component.ts†L264-L283】 |
+| `expectedGrowthPct` | Expected Growth % | percent | — | min -50, max 100, step 0.5 | Controls growth scenarios across new/existing schemas.【F:src/app/existing-store/shared/fields.dictionary.ts†L166-L172】【F:src/app/existing-store/income-drivers/goals.config.ts†L10-L109】 |
+| `handlesTaxRush` | Handles TaxRush | boolean | — | — | Boolean toggle gating TaxRush-dependent controls.【F:src/app/existing-store/shared/fields.dictionary.ts†L174-L178】【F:src/app/existing-store/income-drivers/goals.config.ts†L10-L109】 |
+| `lastYearRevenue` | Prior-Year Revenue | money | `lastYearGrossFees` | min 0, step 1 | Derived revenue using injected prior-year metrics for alias parity.【F:src/app/existing-store/shared/fields.dictionary.ts†L180-L188】【F:src/app/components/income-drivers/income-drivers.component.ts†L439-L445】【F:src/app/components/prior-year-performance/prior-year-performance.component.ts†L65-L83】 |
+| `netIncome` | Net Income | money | `lastYearRevenue`, `lastYearExpenses` | — | Summary metric emitted by prior-year normalizer and rendered via dictionary labels.【F:src/app/existing-store/shared/fields.dictionary.ts†L190-L197】【F:src/app/components/prior-year-performance/prior-year-performance.component.ts†L65-L83】【F:src/app/existing-store/shared/calc.util.ts†L110-L137】 |
+
+## Trail Marker
+1. Add dictionary entries for prior-year discount and other-income overrides to unlock full alias coverage.
+2. Sync validators with forthcoming API contracts once upstream payload requirements land.
+3. Document schema-specific business rules (e.g., TaxRush mandates in CA) alongside the dictionary for quick auditing.

--- a/docs/expedition-log/EX-0005_calc-parity.md
+++ b/docs/expedition-log/EX-0005_calc-parity.md
@@ -1,0 +1,37 @@
+# EX-0005 Calc Parity
+
+## Terrain
+- Hardened prior-year and income-driver math into shared utilities with explicit rounding helpers for cents, percentages, and prior-year normalization.【F:src/app/existing-store/shared/calc.util.ts†L3-L137】
+
+## Artifacts
+- `calc.util.ts` exposes pure functions: rounding helpers, discount/TaxRush math, prior-year revenue + net income, and a `normalizePriorYearMetrics` aggregator.【F:src/app/existing-store/shared/calc.util.ts†L3-L137】
+- `calc.util.spec.ts` documents parity vectors, covering legacy React scenarios, new boundary guards (tiny percentages, zeros, non-integer averages), and normalization fallbacks.【F:src/app/existing-store/shared/calc.util.spec.ts†L1-L211】
+
+## Fault Lines
+- Missing vector: `calculateTaxRushGrossFees` case without avg fee or gross fees still pending to mirror React fail-safe.
+
+## Hypotheses
+- Aligning rounding behavior with currency conventions will keep Angular results consistent with the React reference and reduce penny drift.
+
+## Evidence
+| Function | Scenario | Expected | Source |
+|----------|----------|----------|--------|
+| `round2` | 10.005 cents rounding | 10.01 | 【F:src/app/existing-store/shared/calc.util.spec.ts†L17-L23】 |
+| `toPct1dp` | 12.35 rounds up | 12.4 | 【F:src/app/existing-store/shared/calc.util.spec.ts†L26-L33】 |
+| `calculateDiscountPct` | 206000 gross, 6180 discount | 3 | 【F:src/app/existing-store/shared/calc.util.spec.ts†L36-L43】 |
+| `calculateDiscountAmount` | 999999.99 gross, 0.1% | 1000 | 【F:src/app/existing-store/shared/calc.util.spec.ts†L46-L53】 |
+| `calculateAvgNetFee` | 206000 ÷ 1680 | 122.62 | 【F:src/app/existing-store/shared/calc.util.spec.ts†L60-L67】 |
+| `calculateTaxPrepIncome` | 100000 gross default discount | 97000 | 【F:src/app/existing-store/shared/calc.util.spec.ts†L70-L80】 |
+| `calculateTaxRushGrossFees` | fallback avg from gross/returns | 29428.8 | 【F:src/app/existing-store/shared/calc.util.spec.ts†L94-L105】 |
+| `calculateTaxRushReturnsPct` | 252 of 1680 | 15 | 【F:src/app/existing-store/shared/calc.util.spec.ts†L108-L115】 |
+| `calculateTaxRushReturnsCount` | 1600 @ 12.5% | 200 | 【F:src/app/existing-store/shared/calc.util.spec.ts†L118-L125】 |
+| `defaultTaxRushReturns` | 1680 total | 252 | 【F:src/app/existing-store/shared/calc.util.spec.ts†L128-L135】 |
+| `calculateLastYearRevenue` | 100000.55 − 3000.12 + 0.2 | 97000.63 | 【F:src/app/existing-store/shared/calc.util.spec.ts†L138-L145】 |
+| `calculateTotalExpensesFromGross` | 200000 × 0.76 | 152000 | 【F:src/app/existing-store/shared/calc.util.spec.ts†L148-L155】 |
+| `calculateNetIncome` | 202320 − 150000.12 | 52319.88 | 【F:src/app/existing-store/shared/calc.util.spec.ts†L158-L165】 |
+| `normalizePriorYearMetrics` | React baseline payload | snapshot parity | 【F:src/app/existing-store/shared/calc.util.spec.ts†L168-L209】 |
+
+## Trail Marker
+1. Capture TODO vector for `calculateTaxRushGrossFees` with zeroed inputs.
+2. Backfill Angular callers to adopt `round2` outputs end-to-end.
+3. Add integration test confirming wizard summaries align with util outputs.

--- a/docs/expedition-log/EX-0006_income-drivers.md
+++ b/docs/expedition-log/EX-0006_income-drivers.md
@@ -1,0 +1,24 @@
+# EX-0006 Income Drivers
+
+## Terrain
+- Standalone IncomeDriversComponent composes a reactive form from schemaFor, the field dictionary, and calc util derivations, keeping template markup display-only.【F:src/app/components/income-drivers/income-drivers.component.ts†L46-L466】
+
+## Artifacts
+- Field dictionary lists income-driver keys, validators, and deriveFrom wiring consumed by the builder.【F:src/app/existing-store/shared/fields.dictionary.ts†L1-L197】
+- Goals schema maps mode×region×storeType to field arrays with TODO rules for TaxRush and growth presets.【F:src/app/existing-store/income-drivers/goals.config.ts†L1-L134】
+- Calc util adds gross tax prep, revenue, and expense helpers leveraged by derived controls.【F:src/app/existing-store/shared/calc.util.ts†L3-L137】
+- Spec suite exercises the helpers alongside legacy parity vectors and normalization fallbacks.【F:src/app/existing-store/shared/calc.util.spec.ts†L1-L211】
+
+## Fault Lines
+- Discount amount is now locked behind deriveFrom; confirm whether UX still needs manual override symmetry with the percent field.【F:src/app/existing-store/shared/fields.dictionary.ts†L101-L123】【F:src/app/components/income-drivers/income-drivers.component.ts†L422-L426】
+- Last-year revenue derivation depends on injected priorYear discounts/other income; future API payloads must surface those values explicitly.【F:src/app/components/income-drivers/income-drivers.component.ts†L439-L445】
+
+## Evidence
+- Derived control subscriptions debounce dependency changes before writing back util results into disabled form controls.【F:src/app/components/income-drivers/income-drivers.component.ts†L306-L358】
+- Form state emitter packages raw values, validity, and touch state on every value/status change for shell listeners.【F:src/app/components/income-drivers/income-drivers.component.ts†L361-L387】
+- Gross-fee and expense helpers validated with 76% benchmark vectors to hold parity.【F:src/app/existing-store/shared/calc.util.spec.ts†L84-L155】
+
+## Trail Marker
+1. Cross-check schema field coverage against live wizard toggles to catch missing conditions.
+2. Add UX affordance for manual discount amount overrides if parity testing flags regressions.
+3. Integrate the component into the shell demo once region/store selectors are ready.

--- a/docs/expedition-log/EX-0007_prior-year.md
+++ b/docs/expedition-log/EX-0007_prior-year.md
@@ -1,0 +1,28 @@
+# EX-0007 Prior Year
+
+## Terrain
+- PriorYearPerformanceComponent now delegates all math to shared calc utilities, emitting normalized metrics for shell consumers while sourcing all labels from the shared dictionary.【F:src/app/components/prior-year-performance/prior-year-performance.component.ts†L32-L238】
+
+## Artifacts
+- Dictionary-driven template renders inputs/summary metrics without hard-coded copy, binding validators and units from field specs.【F:src/app/components/prior-year-performance/prior-year-performance.component.ts†L42-L132】
+- Reactive form captures raw prior-year inputs and streams debounced value changes into `normalizePriorYearMetrics`.【F:src/app/components/prior-year-performance/prior-year-performance.component.ts†L188-L238】
+- Calc util consolidates discount, revenue, net income, and TaxRush helpers into a normalization pipeline for parity comparisons.【F:src/app/existing-store/shared/calc.util.ts†L3-L137】
+- Spec suite asserts both individual helpers and the aggregated normalizer using React baseline payloads.【F:src/app/existing-store/shared/calc.util.spec.ts†L138-L209】
+
+## Fault Lines
+- Normalizer still relies on injected discount/other income values; without explicit prior-year fields, user edits remain constrained to provided metrics.【F:src/app/components/income-drivers/income-drivers.component.ts†L264-L283】
+
+## Hypotheses
+- Surfacing prior-year discount and other-income overrides alongside the normalizer will let stakeholders validate parity against historical adjustments.
+
+## Evidence
+| Example | Calculation | Expected | Source |
+|---------|-------------|----------|--------|
+| Discount % | `calculateDiscountPct(206000, 6180)` | 3.0% | 【F:src/app/existing-store/shared/calc.util.spec.ts†L40-L47】 |
+| Net Income | `calculateNetIncome(202320, 150000.12)` | 52,319.88 | 【F:src/app/existing-store/shared/calc.util.spec.ts†L158-L165】 |
+| Normalized Snapshot | `normalizePriorYearMetrics` React payload | Matches baseline metrics | 【F:src/app/existing-store/shared/calc.util.spec.ts†L168-L209】 |
+
+## Trail Marker
+1. Add explicit prior-year discount and other-income form controls to complement the normalizer inputs.
+2. Feed normalized metrics into projected-performance cards to validate downstream parity.
+3. Extend specs with zero-input guard cases for `calculateTaxRushGrossFees` to mirror React fail-safe logic.

--- a/docs/expedition-log/EX-0008_existing-store-shell.md
+++ b/docs/expedition-log/EX-0008_existing-store-shell.md
@@ -1,0 +1,30 @@
+# EX-0008 Existing Store Shell
+
+## Terrain
+- Routed a dedicated existing-store playground that swaps out the legacy dashboard view when `/existing-store` is requested.
+- Shell coordinates prior-year normalization with downstream goals form while keeping region and store-type toggles in one control bar.
+
+## Artifacts
+- `existing-store` route lazy-loads the standalone shell component for experimentation without touching the dashboard flow.
+- Shell stitches `app-prior-year-performance` raw inputs and `app-income-drivers` goals panel, feeding prior-year metrics directly into the reactive goals form.
+- Prior-year calculator emits rounded metrics from shared calc utilities and models the alias pair for `lastYearGrossFees` ↔ `lastYearRevenue`.
+
+## Fault Lines
+- Navigation chrome lacks a link into `/existing-store`, so manual URL entry is required for now.
+- Goals snapshot dumps raw form JSON without formatting, which may overwhelm non-technical reviewers.
+
+## Hypotheses
+- Wiring a footer/header hook into the new route will let stakeholders jump between legacy dashboard and existing-store parity views quickly.
+- Formatting the snapshot (or piping it through a formatter) will make validation of preserved field values easier during demos.
+
+## Evidence
+- Route definition for the experimental shell.【F:src/app/app.routes.ts†L1-L11】
+- App component toggles between legacy content and router outlet based on the active URL, unsubscribing on destroy.【F:src/app/app.ts†L39-L129】【F:src/app/app.ts†L200-L330】
+- Existing store shell hosts region/store selectors, prior-year component, goals component, and emits form snapshots.【F:src/app/components/existing-store-shell/existing-store-shell.component.ts†L14-L174】
+- Prior-year component normalizes raw answers into metrics via calc util helpers before emitting.【F:src/app/components/prior-year-performance/prior-year-performance.component.ts†L18-L208】
+- Income drivers apply prior-year aliases so `lastYearRevenue` mirrors `lastYearGrossFees` inputs.【F:src/app/components/income-drivers/income-drivers.component.ts†L246-L266】
+
+## Trail Marker
+1. Expose a navigation affordance (header link or debug toggle) into the existing-store shell.
+2. Add formatted snapshots (table or key metrics) to replace the raw JSON dump.
+3. Expand shell coverage with persistence plumbing once stakeholder data-entry flows are finalized.

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,11 @@
 import { Routes } from '@angular/router';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  {
+    path: 'existing-store',
+    loadComponent: () =>
+      import('./components/existing-store-shell/existing-store-shell.component').then(
+        m => m.ExistingStoreShellComponent
+      ),
+  },
+];

--- a/src/app/components/existing-store-shell/existing-store-shell.component.ts
+++ b/src/app/components/existing-store-shell/existing-store-shell.component.ts
@@ -1,0 +1,174 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { PriorYearPerformanceComponent } from '../prior-year-performance/prior-year-performance.component';
+import { IncomeDriversComponent } from '../income-drivers/income-drivers.component';
+import { PriorYearMetrics, PriorYearRawMetrics } from '../../existing-store/shared/prior-year.models';
+
+interface FormStateSnapshot {
+  value: Record<string, unknown>;
+  valid: boolean;
+  touched: boolean;
+}
+
+@Component({
+  selector: 'app-existing-store-shell',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, PriorYearPerformanceComponent, IncomeDriversComponent],
+  template: `
+    <section class="existing-shell">
+      <header class="existing-shell__header">
+        <h2>Existing Store Overview</h2>
+        <p class="existing-shell__subtitle">Toggle region and store type to mirror production parity scenarios.</p>
+      </header>
+
+      <form [formGroup]="contextForm" class="existing-shell__context">
+        <label class="existing-shell__control">
+          <span>Region</span>
+          <select formControlName="region" class="existing-shell__select">
+            <option *ngFor="let option of regions" [value]="option">{{ option }}</option>
+          </select>
+        </label>
+
+        <label class="existing-shell__control">
+          <span>Store Type</span>
+          <select formControlName="storeType" class="existing-shell__select">
+            <option *ngFor="let option of storeTypes" [value]="option">{{ option }}</option>
+          </select>
+        </label>
+      </form>
+
+      <div class="existing-shell__panels">
+        <app-prior-year-performance
+          class="existing-shell__panel"
+          [region]="region"
+          [storeType]="storeType"
+          [raw]="priorYearRaw"
+          (metricsChange)="onPriorYearMetrics($event)"
+        ></app-prior-year-performance>
+
+        <app-income-drivers
+          class="existing-shell__panel"
+          [displayTitle]="'Performance Goals'"
+          [mode]="'existing'"
+          [region]="region"
+          [storeType]="storeType"
+          [priorYear]="priorYearMetrics"
+          (formState)="onFormState($event)"
+        ></app-income-drivers>
+      </div>
+
+      <section class="existing-shell__snapshot" *ngIf="formState">
+        <h3>Goals Form Snapshot</h3>
+        <p><strong>Valid:</strong> {{ formState.valid }}</p>
+        <p><strong>Touched:</strong> {{ formState.touched }}</p>
+        <pre>{{ formState.value | json }}</pre>
+      </section>
+    </section>
+  `,
+  styles: [
+    `
+      .existing-shell {
+        display: grid;
+        gap: 1.5rem;
+        padding: 2rem;
+        max-width: 1200px;
+        margin: 0 auto;
+      }
+
+      .existing-shell__header {
+        display: grid;
+        gap: 0.35rem;
+      }
+
+      .existing-shell__subtitle {
+        color: #4b5563;
+        margin: 0;
+      }
+
+      .existing-shell__context {
+        display: flex;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+
+      .existing-shell__control {
+        display: grid;
+        gap: 0.25rem;
+        font-weight: 600;
+        color: #1f2937;
+      }
+
+      .existing-shell__select {
+        padding: 0.5rem 0.75rem;
+        border-radius: 0.5rem;
+        border: 1px solid #d1d5db;
+        background: #ffffff;
+        min-width: 160px;
+      }
+
+      .existing-shell__panels {
+        display: grid;
+        gap: 1.5rem;
+      }
+
+      .existing-shell__panel {
+        width: 100%;
+      }
+
+      .existing-shell__snapshot {
+        border: 1px solid #e5e7eb;
+        border-radius: 0.75rem;
+        padding: 1rem;
+        background: #f9fafb;
+        overflow: auto;
+      }
+
+      pre {
+        margin: 0;
+        background: transparent;
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ExistingStoreShellComponent {
+  readonly regions = ['US', 'CA'];
+  readonly storeTypes = ['Franchise', 'Company'];
+
+  readonly contextForm: FormGroup = this.fb.group({
+    region: ['US'],
+    storeType: ['Franchise'],
+  });
+
+  priorYearRaw: PriorYearRawMetrics = {
+    grossFees: 206000,
+    discountAmount: 6180,
+    otherIncome: 2500,
+    expenses: 150000,
+    taxPrepReturns: 1680,
+    taxRushReturns: 252,
+    taxRushAvgNetFee: 125,
+  };
+
+  priorYearMetrics?: PriorYearMetrics;
+  formState?: FormStateSnapshot;
+
+  constructor(private readonly fb: FormBuilder) {}
+
+  get region(): string {
+    return this.contextForm.get('region')?.value ?? 'US';
+  }
+
+  get storeType(): string {
+    return this.contextForm.get('storeType')?.value ?? 'Franchise';
+  }
+
+  onPriorYearMetrics(metrics: PriorYearMetrics): void {
+    this.priorYearMetrics = metrics;
+  }
+
+  onFormState(state: FormStateSnapshot): void {
+    this.formState = state;
+  }
+}

--- a/src/app/components/income-drivers/income-drivers.component.ts
+++ b/src/app/components/income-drivers/income-drivers.component.ts
@@ -1,0 +1,467 @@
+import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnDestroy,
+  Output,
+  SimpleChanges,
+} from '@angular/core';
+import {
+  FormBuilder,
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  ValidatorFn,
+  Validators,
+} from '@angular/forms';
+import { combineLatest, debounceTime, startWith, Subscription } from 'rxjs';
+import {
+  calculateDiscountAmount,
+  calculateGrossTaxPrepFees,
+  calculateLastYearRevenue,
+  calculateTaxPrepIncome,
+  calculateTaxRushGrossFees,
+  calculateTaxRushReturnsPct,
+  calculateTotalExpensesFromGross,
+} from '../../existing-store/shared/calc.util';
+import { FieldKey, FieldSpec, FIELDS } from '../../existing-store/shared/fields.dictionary';
+import { GoalsSchemaEntry, Mode, schemaFor } from '../../existing-store/income-drivers/goals.config';
+import { PriorYearMetrics } from '../../existing-store/shared/prior-year.models';
+
+interface FormStatePayload {
+  value: Record<string, unknown>;
+  valid: boolean;
+  touched: boolean;
+}
+
+type DerivationFn = (inputs: Partial<Record<FieldKey, number>>) => number;
+
+@Component({
+  selector: 'app-income-drivers',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  template: `
+    <section class="income-drivers" *ngIf="form">
+      <header class="income-drivers__header">
+        <h3>{{ displayTitle || 'Income Drivers' }}</h3>
+      </header>
+
+      <form [formGroup]="form" class="income-drivers__form">
+        <ng-container *ngFor="let field of visibleFields">
+          <div class="income-drivers__field" [class.readonly]="form.get(field.key)?.disabled">
+            <label [attr.for]="field.key" class="income-drivers__label">
+              <span class="income-drivers__label-text">
+                {{ field.label }}
+                <span *ngIf="field.unit" class="income-drivers__unit">({{ field.unit }})</span>
+              </span>
+              <span *ngIf="isRequired(field)" class="income-drivers__required">*</span>
+            </label>
+
+            <ng-container [ngSwitch]="field.type">
+              <input
+                *ngSwitchCase="'money'"
+                type="number"
+                class="income-drivers__input"
+                [formControlName]="field.key"
+                [attr.id]="field.key"
+                [attr.step]="field.validators?.step ?? 1"
+                [attr.min]="field.validators?.min"
+                [attr.max]="field.validators?.max"
+                [attr.placeholder]="field.unit === '$' ? '0.00' : ''"
+              />
+
+              <input
+                *ngSwitchCase="'percent'"
+                type="number"
+                class="income-drivers__input"
+                [formControlName]="field.key"
+                [attr.id]="field.key"
+                [attr.step]="field.validators?.step ?? 0.1"
+                [attr.min]="field.validators?.min"
+                [attr.max]="field.validators?.max"
+              />
+
+              <input
+                *ngSwitchCase="'number'"
+                type="number"
+                class="income-drivers__input"
+                [formControlName]="field.key"
+                [attr.id]="field.key"
+                [attr.step]="field.validators?.step ?? 1"
+                [attr.min]="field.validators?.min"
+                [attr.max]="field.validators?.max"
+              />
+
+              <input
+                *ngSwitchCase="'text'"
+                type="text"
+                class="income-drivers__input"
+                [formControlName]="field.key"
+                [attr.id]="field.key"
+              />
+
+              <input
+                *ngSwitchCase="'boolean'"
+                type="checkbox"
+                class="income-drivers__checkbox"
+                [formControlName]="field.key"
+                [attr.id]="field.key"
+              />
+            </ng-container>
+
+            <small class="income-drivers__help" *ngIf="field.help">{{ field.help }}</small>
+            <small class="income-drivers__error" *ngIf="showError(field.key)">
+              Invalid value
+            </small>
+          </div>
+        </ng-container>
+      </form>
+    </section>
+  `,
+  styles: [
+    `
+      .income-drivers {
+        display: block;
+        padding: 1rem;
+        border: 1px solid #e5e7eb;
+        border-radius: 0.5rem;
+        background: #ffffff;
+      }
+      .income-drivers__header {
+        margin-bottom: 1rem;
+      }
+      .income-drivers__form {
+        display: grid;
+        gap: 1rem;
+      }
+      .income-drivers__field {
+        display: grid;
+        gap: 0.35rem;
+      }
+      .income-drivers__field.readonly .income-drivers__input {
+        background: #f5f5f5;
+      }
+      .income-drivers__label {
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .income-drivers__label-text {
+        display: flex;
+        align-items: baseline;
+        gap: 0.35rem;
+      }
+
+      .income-drivers__unit {
+        font-weight: 400;
+        color: #6b7280;
+        font-size: 0.85rem;
+      }
+      .income-drivers__required {
+        color: #b91c1c;
+        margin-left: 0.25rem;
+      }
+      .income-drivers__input {
+        padding: 0.5rem;
+        border: 1px solid #d1d5db;
+        border-radius: 0.375rem;
+      }
+      .income-drivers__checkbox {
+        width: 1rem;
+        height: 1rem;
+      }
+      .income-drivers__help {
+        color: #6b7280;
+        font-size: 0.75rem;
+      }
+      .income-drivers__error {
+        color: #b91c1c;
+        font-size: 0.75rem;
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class IncomeDriversComponent implements OnChanges, OnDestroy {
+  @Input() mode: Mode = 'new';
+  @Input() region!: string;
+  @Input() storeType!: string;
+  @Input() priorYear?: PriorYearMetrics;
+  @Input() displayTitle = 'Income Drivers';
+
+  @Output() formState = new EventEmitter<FormStatePayload>();
+
+  form?: FormGroup;
+  visibleFields: FieldSpec[] = [];
+
+  private schema?: GoalsSchemaEntry;
+  private valueSub?: Subscription;
+  private statusSub?: Subscription;
+  private derivedSubs: Subscription[] = [];
+
+  constructor(private readonly fb: FormBuilder) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    const shouldRebuild =
+      !this.form ||
+      changes['mode'] ||
+      changes['region'] ||
+      changes['storeType'];
+
+    if (shouldRebuild && this.region && this.storeType) {
+      this.buildForm();
+    } else if (changes['priorYear'] && this.form) {
+      this.applyPriorYear();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.teardownSubscriptions();
+  }
+
+  private buildForm(): void {
+    this.schema = schemaFor(this.mode ?? 'new', this.region, this.storeType);
+    this.visibleFields = this.schema.fields.map(field => FIELDS[field]).filter(Boolean);
+
+    const controlsConfig: Record<string, FormControl> = {};
+    const previousValues = this.form?.getRawValue() ?? {};
+
+    for (const field of this.schema.fields) {
+      const spec = FIELDS[field];
+      if (!spec) {
+        continue;
+      }
+
+      const validators = this.toValidators(spec.validators);
+      const initial = this.resolveInitialValue(field, spec, previousValues);
+      const control = this.fb.control(initial, validators);
+
+      if (spec.deriveFrom?.length) {
+        control.disable({ emitEvent: false });
+      }
+
+      controlsConfig[field] = control;
+    }
+
+    this.teardownSubscriptions();
+    this.form = this.fb.group(controlsConfig);
+    this.applyPriorYear();
+    this.setupDerivedCalculations();
+    this.subscribeToFormState();
+    this.emitFormState();
+  }
+
+  private applyPriorYear(): void {
+    if (!this.form || !this.priorYear) {
+      return;
+    }
+
+    const mapping: Partial<Record<FieldKey, keyof PriorYearMetrics>> = {
+      lastYearGrossFees: 'grossFees',
+      lastYearExpenses: 'expenses',
+      lastYearReturns: 'taxPrepReturns',
+      lastYearRevenue: 'revenue',
+      taxRushReturns: 'taxRushReturns',
+      grossTaxRushFees: 'taxRushGrossFees',
+    };
+
+    Object.entries(mapping).forEach(([fieldKey, priorKey]) => {
+      const control = this.form?.get(fieldKey);
+      if (!control || priorKey === undefined) {
+        return;
+      }
+
+      const value = this.priorYear?.[priorKey];
+      if (value !== undefined && value !== null) {
+        control.setValue(value, { emitEvent: false });
+      }
+    });
+  }
+
+  private resolveInitialValue(
+    field: FieldKey,
+    spec: FieldSpec,
+    previousValues: Record<string, unknown>
+  ): unknown {
+    if (previousValues && previousValues[field] !== undefined) {
+      return previousValues[field];
+    }
+
+    if (spec.type === 'boolean') {
+      return false;
+    }
+
+    if (field === 'discountsPct') {
+      return 3; // default discount baseline when not provided
+    }
+
+    return null;
+  }
+
+  private setupDerivedCalculations(): void {
+    if (!this.form || !this.schema) {
+      return;
+    }
+
+    for (const field of this.schema.fields) {
+      const spec = FIELDS[field];
+      if (!spec?.deriveFrom?.length) {
+        continue;
+      }
+
+      const derivation = this.getDerivation(field);
+      if (!derivation) {
+        continue;
+      }
+
+      const controls = spec.deriveFrom
+        .map(dep => this.form?.get(dep))
+        .filter((ctrl): ctrl is FormControl => !!ctrl);
+
+      if (!controls.length) {
+        continue;
+      }
+
+      const sub = combineLatest(
+        controls.map(control => control.valueChanges.pipe(startWith(control.value ?? 0)))
+      )
+        .pipe(debounceTime(75))
+        .subscribe(values => {
+          const inputs: Partial<Record<FieldKey, number>> = {};
+          spec.deriveFrom!.forEach((dep, idx) => {
+            inputs[dep] = Number(values[idx]) || 0;
+          });
+
+          const nextValue = derivation(inputs);
+          const target = this.form?.get(field);
+          if (target) {
+            target.setValue(nextValue, { emitEvent: false });
+          }
+        });
+
+      this.derivedSubs.push(sub);
+
+      const initialInputs: Partial<Record<FieldKey, number>> = {};
+      spec.deriveFrom.forEach(dep => {
+        initialInputs[dep] = Number(this.form?.get(dep)?.value) || 0;
+      });
+      const initial = derivation(initialInputs);
+      const target = this.form.get(field);
+      if (target) {
+        target.setValue(initial, { emitEvent: false });
+      }
+    }
+  }
+
+  private subscribeToFormState(): void {
+    if (!this.form) {
+      return;
+    }
+
+    this.valueSub = this.form.valueChanges.pipe(debounceTime(100)).subscribe(() => {
+      this.emitFormState();
+    });
+
+    this.statusSub = this.form.statusChanges.subscribe(() => {
+      this.emitFormState();
+    });
+  }
+
+  private emitFormState(): void {
+    if (!this.form) {
+      return;
+    }
+
+    const payload: FormStatePayload = {
+      value: this.form.getRawValue(),
+      valid: this.form.valid,
+      touched: this.isFormTouched(this.form),
+    };
+
+    this.formState.emit(payload);
+  }
+
+  private teardownSubscriptions(): void {
+    this.valueSub?.unsubscribe();
+    this.statusSub?.unsubscribe();
+    this.derivedSubs.forEach(sub => sub.unsubscribe());
+    this.derivedSubs = [];
+  }
+
+  private toValidators(config?: FieldSpec['validators']): ValidatorFn[] {
+    if (!config) {
+      return [];
+    }
+
+    const validators: ValidatorFn[] = [];
+
+    if (config.required) {
+      validators.push(Validators.required);
+    }
+    if (config.min !== undefined) {
+      validators.push(Validators.min(config.min));
+    }
+    if (config.max !== undefined) {
+      validators.push(Validators.max(config.max));
+    }
+    if (config.pattern) {
+      validators.push(Validators.pattern(config.pattern));
+    }
+
+    return validators;
+  }
+
+  private getDerivation(field: FieldKey): DerivationFn | undefined {
+    switch (field) {
+      case 'grossTaxPrepFees':
+        return inputs => calculateGrossTaxPrepFees(inputs.avgNetFee ?? 0, inputs.taxPrepReturns ?? 0);
+      case 'discountsAmt':
+        return inputs => calculateDiscountAmount(inputs.grossTaxPrepFees ?? 0, inputs.discountsPct ?? 0);
+      case 'netTaxPrepFees':
+        return inputs => calculateTaxPrepIncome(inputs.grossTaxPrepFees ?? 0, inputs.discountsAmt ?? 0);
+      case 'grossTaxRushFees':
+        return inputs =>
+          calculateTaxRushGrossFees(
+            inputs.taxRushReturns ?? 0,
+            inputs.taxRushFee,
+            inputs.grossTaxPrepFees,
+            inputs.taxPrepReturns
+          );
+      case 'totalExpenses':
+        return inputs => calculateTotalExpensesFromGross(inputs.grossTaxPrepFees ?? 0);
+      case 'taxRushPercentage':
+        return inputs => calculateTaxRushReturnsPct(inputs.taxRushReturns ?? 0, inputs.taxPrepReturns ?? 0);
+      case 'lastYearRevenue':
+        return inputs =>
+          calculateLastYearRevenue(
+            inputs.lastYearGrossFees ?? 0,
+            this.priorYear?.discountAmount ?? 0,
+            this.priorYear?.otherIncome ?? 0
+          );
+      default:
+        return undefined;
+    }
+  }
+
+  private isRequired(field: FieldSpec): boolean {
+    return !!field.validators?.required;
+  }
+
+  private showError(fieldKey: string): boolean {
+    if (!this.form) {
+      return false;
+    }
+
+    const control = this.form.get(fieldKey);
+    return !!control && control.invalid && (control.dirty || control.touched);
+  }
+
+  private isFormTouched(group: FormGroup): boolean {
+    return Object.values(group.controls).some(control => control.touched || control.dirty);
+  }
+}

--- a/src/app/components/prior-year-performance/prior-year-performance.component.ts
+++ b/src/app/components/prior-year-performance/prior-year-performance.component.ts
@@ -1,0 +1,259 @@
+import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  Output,
+  SimpleChanges,
+} from '@angular/core';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { debounceTime, Subscription } from 'rxjs';
+import { normalizePriorYearMetrics } from '../../existing-store/shared/calc.util';
+import { FieldKey, FIELDS } from '../../existing-store/shared/fields.dictionary';
+import { PriorYearMetrics, PriorYearRawMetrics } from '../../existing-store/shared/prior-year.models';
+
+type PriorYearControl = keyof PriorYearRawMetrics;
+
+interface PriorYearInputConfig {
+  control: PriorYearControl;
+  fieldKey: FieldKey;
+}
+
+interface PriorYearSummaryConfig {
+  fieldKey: FieldKey;
+  valueKey: keyof PriorYearMetrics;
+  digitsInfo: string;
+}
+
+@Component({
+  selector: 'app-prior-year-performance',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  template: `
+    <section class="prior-year" [formGroup]="form">
+      <header class="prior-year__header">
+        <h3>Prior Year Performance</h3>
+      </header>
+
+      <div class="prior-year__grid">
+        <div class="prior-year__inputs">
+          <div class="prior-year__field" *ngFor="let input of inputFields">
+            <label class="prior-year__label" [attr.for]="input.control">
+              {{ fields[input.fieldKey].label }}
+              <span *ngIf="fields[input.fieldKey].unit" class="prior-year__unit">
+                ({{ fields[input.fieldKey].unit }})
+              </span>
+            </label>
+
+            <input
+              type="number"
+              class="prior-year__input"
+              [formControlName]="input.control"
+              [attr.id]="input.control"
+              [attr.step]="getStep(input.fieldKey)"
+              [attr.min]="getMin(input.fieldKey)"
+              [attr.max]="getMax(input.fieldKey)"
+              [attr.placeholder]="getPlaceholder(input.fieldKey)"
+            />
+          </div>
+        </div>
+
+        <div class="prior-year__summary">
+          <div class="prior-year__metric" *ngFor="let summary of summaryMetrics">
+            <span class="prior-year__metric-label">
+              {{ fields[summary.fieldKey].label }}
+            </span>
+            <span class="prior-year__metric-value">
+              <ng-container [ngSwitch]="fields[summary.fieldKey].unit">
+                <ng-container *ngSwitchCase="'$'">
+                  {{ '$' }}{{ metrics[summary.valueKey] | number: summary.digitsInfo }}
+                </ng-container>
+                <ng-container *ngSwitchCase="'%'">
+                  {{ metrics[summary.valueKey] | number: summary.digitsInfo }}%
+                </ng-container>
+                <ng-container *ngSwitchDefault>
+                  {{ metrics[summary.valueKey] | number: summary.digitsInfo }}
+                </ng-container>
+              </ng-container>
+            </span>
+          </div>
+        </div>
+      </div>
+    </section>
+  `,
+  styles: [
+    `
+      .prior-year {
+        display: block;
+        padding: 1rem;
+        border: 1px solid #e5e7eb;
+        border-radius: 0.75rem;
+        background-color: #ffffff;
+      }
+
+      .prior-year__header {
+        margin-bottom: 1rem;
+      }
+
+      .prior-year__grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        gap: 1.5rem;
+      }
+
+      .prior-year__inputs {
+        display: grid;
+        gap: 0.75rem;
+      }
+
+      .prior-year__field {
+        display: grid;
+        gap: 0.35rem;
+      }
+
+      .prior-year__label {
+        display: flex;
+        align-items: center;
+        gap: 0.35rem;
+        font-weight: 600;
+        color: #1f2937;
+      }
+
+      .prior-year__unit {
+        font-weight: 400;
+        color: #6b7280;
+        font-size: 0.85rem;
+      }
+
+      .prior-year__input {
+        padding: 0.5rem 0.75rem;
+        border: 1px solid #d1d5db;
+        border-radius: 0.5rem;
+      }
+
+      .prior-year__summary {
+        display: grid;
+        gap: 0.75rem;
+        align-content: start;
+        background: #f9fafb;
+        border: 1px solid #e5e7eb;
+        border-radius: 0.75rem;
+        padding: 1rem;
+      }
+
+      .prior-year__metric {
+        display: flex;
+        justify-content: space-between;
+        font-size: 0.95rem;
+      }
+
+      .prior-year__metric-label {
+        color: #4b5563;
+      }
+
+      .prior-year__metric-value {
+        font-weight: 600;
+        color: #111827;
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PriorYearPerformanceComponent implements OnInit, OnChanges, OnDestroy {
+  @Input() region!: string;
+  @Input() storeType!: string;
+  @Input() raw: PriorYearRawMetrics = {};
+
+  @Output() metricsChange = new EventEmitter<PriorYearMetrics>();
+
+  readonly fields = FIELDS;
+
+  readonly inputFields: PriorYearInputConfig[] = [
+    { control: 'grossFees', fieldKey: 'lastYearGrossFees' },
+    { control: 'discountAmount', fieldKey: 'discountsAmt' },
+    { control: 'otherIncome', fieldKey: 'otherIncome' },
+    { control: 'expenses', fieldKey: 'lastYearExpenses' },
+    { control: 'taxPrepReturns', fieldKey: 'taxPrepReturns' },
+    { control: 'taxRushReturns', fieldKey: 'taxRushReturns' },
+    { control: 'taxRushAvgNetFee', fieldKey: 'taxRushFee' },
+  ];
+
+  readonly summaryMetrics: PriorYearSummaryConfig[] = [
+    { fieldKey: 'discountsPct', valueKey: 'discountPct', digitsInfo: '1.0-1' },
+    { fieldKey: 'avgNetFee', valueKey: 'avgNetFee', digitsInfo: '1.0-2' },
+    { fieldKey: 'netTaxPrepFees', valueKey: 'taxPrepIncome', digitsInfo: '1.0-2' },
+    { fieldKey: 'grossTaxRushFees', valueKey: 'taxRushGrossFees', digitsInfo: '1.0-2' },
+    { fieldKey: 'lastYearRevenue', valueKey: 'revenue', digitsInfo: '1.0-2' },
+    { fieldKey: 'netIncome', valueKey: 'netIncome', digitsInfo: '1.0-2' },
+  ];
+
+  form!: FormGroup;
+  metrics: PriorYearMetrics = normalizePriorYearMetrics({});
+
+  private valueSub?: Subscription;
+
+  constructor(private readonly fb: FormBuilder) {}
+
+  ngOnInit(): void {
+    this.buildForm();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['raw'] && this.form) {
+      this.form.patchValue(this.raw ?? {}, { emitEvent: false });
+      this.metrics = normalizePriorYearMetrics(this.form.getRawValue());
+      this.metricsChange.emit(this.metrics);
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.valueSub?.unsubscribe();
+  }
+
+  getStep(fieldKey: FieldKey): number | null {
+    return this.fields[fieldKey].validators?.step ?? null;
+  }
+
+  getMin(fieldKey: FieldKey): number | null {
+    return this.fields[fieldKey].validators?.min ?? null;
+  }
+
+  getMax(fieldKey: FieldKey): number | null {
+    return this.fields[fieldKey].validators?.max ?? null;
+  }
+
+  getPlaceholder(fieldKey: FieldKey): string | null {
+    const spec = this.fields[fieldKey];
+    if (spec.unit === '$') {
+      return '0.00';
+    }
+    if (spec.unit === '%') {
+      return '0.0';
+    }
+    return null;
+  }
+
+  private buildForm(): void {
+    this.form = this.fb.group({
+      grossFees: [this.raw?.grossFees ?? null, [Validators.min(0)]],
+      discountAmount: [this.raw?.discountAmount ?? null, [Validators.min(0)]],
+      otherIncome: [this.raw?.otherIncome ?? null, [Validators.min(0)]],
+      expenses: [this.raw?.expenses ?? null, [Validators.min(0)]],
+      taxPrepReturns: [this.raw?.taxPrepReturns ?? null, [Validators.min(0)]],
+      taxRushReturns: [this.raw?.taxRushReturns ?? null, [Validators.min(0)]],
+      taxRushAvgNetFee: [this.raw?.taxRushAvgNetFee ?? null, [Validators.min(0)]],
+    });
+
+    this.metrics = normalizePriorYearMetrics(this.form.getRawValue());
+    this.metricsChange.emit(this.metrics);
+
+    this.valueSub = this.form.valueChanges.pipe(debounceTime(100)).subscribe(value => {
+      this.metrics = normalizePriorYearMetrics(value as PriorYearRawMetrics);
+      this.metricsChange.emit(this.metrics);
+    });
+  }
+}

--- a/src/app/existing-store/income-drivers/goals.config.ts
+++ b/src/app/existing-store/income-drivers/goals.config.ts
@@ -1,0 +1,134 @@
+import { FieldKey } from '../shared/fields.dictionary';
+
+export type Mode = 'new' | 'existing';
+
+export interface GoalsSchemaEntry {
+  fields: FieldKey[];
+  rules?: Record<string, unknown>;
+}
+
+const BASE_NEW_FIELDS: FieldKey[] = [
+  'avgNetFee',
+  'taxPrepReturns',
+  'grossTaxPrepFees',
+  'discountsPct',
+  'discountsAmt',
+  'netTaxPrepFees',
+  'handlesTaxRush',
+  'taxRushReturns',
+  'taxRushPercentage',
+  'taxRushFee',
+  'grossTaxRushFees',
+  'otherIncome',
+  'totalExpenses',
+];
+
+const BASE_EXISTING_FIELDS: FieldKey[] = [
+  'lastYearGrossFees',
+  'lastYearExpenses',
+  'lastYearReturns',
+  'lastYearRevenue',
+  'avgNetFee',
+  'taxPrepReturns',
+  'expectedGrowthPct',
+  'grossTaxPrepFees',
+  'discountsPct',
+  'discountsAmt',
+  'netTaxPrepFees',
+  'handlesTaxRush',
+  'taxRushReturns',
+  'taxRushPercentage',
+  'taxRushFee',
+  'grossTaxRushFees',
+  'otherIncome',
+  'totalExpenses',
+];
+
+export const GOALS_SCHEMA: Record<Mode, Record<string, Record<string, GoalsSchemaEntry>>> = {
+  new: {
+    US: {
+      Franchise: {
+        fields: [...BASE_NEW_FIELDS],
+        rules: {
+          taxRushOptional: true,
+        },
+      },
+      Company: {
+        fields: [...BASE_NEW_FIELDS],
+        rules: {
+          // TODO: confirm if company stores use identical validation thresholds.
+          taxRushOptional: true,
+        },
+      },
+    },
+    CA: {
+      Franchise: {
+        fields: [...BASE_NEW_FIELDS],
+        rules: {
+          // TODO: confirm if TaxRush question is mandatory for CA franchises.
+          taxRushOptional: false,
+        },
+      },
+      Company: {
+        fields: [...BASE_NEW_FIELDS],
+        rules: {
+          taxRushOptional: false,
+        },
+      },
+    },
+  },
+  existing: {
+    US: {
+      Franchise: {
+        fields: [...BASE_EXISTING_FIELDS],
+        rules: {
+          // TODO: confirm expectedGrowthPct presets for franchise vs company.
+          growthPresets: true,
+        },
+      },
+      Company: {
+        fields: [...BASE_EXISTING_FIELDS],
+        rules: {
+          growthPresets: true,
+        },
+      },
+    },
+    CA: {
+      Franchise: {
+        fields: [...BASE_EXISTING_FIELDS],
+        rules: {
+          taxRushOptional: false,
+          growthPresets: true,
+        },
+      },
+      Company: {
+        fields: [...BASE_EXISTING_FIELDS],
+        rules: {
+          taxRushOptional: false,
+          growthPresets: true,
+        },
+      },
+    },
+  },
+};
+
+export function schemaFor(mode: Mode, region: string, storeType: string): GoalsSchemaEntry {
+  const normalizedMode: Mode = mode ?? 'new';
+  const normalizedRegion = (region || 'US').toUpperCase();
+  const normalizedStoreType = storeType || 'Franchise';
+
+  const modeSchema = GOALS_SCHEMA[normalizedMode];
+  const regionSchema = modeSchema[normalizedRegion] ?? modeSchema.US;
+
+  const entry = regionSchema?.[normalizedStoreType];
+  if (entry) {
+    return entry;
+  }
+
+  const fallback = regionSchema?.Franchise;
+  if (fallback) {
+    return fallback;
+  }
+
+  return GOALS_SCHEMA.new.US.Franchise;
+}

--- a/src/app/existing-store/shared/calc.util.spec.ts
+++ b/src/app/existing-store/shared/calc.util.spec.ts
@@ -1,0 +1,211 @@
+import {
+  calculateAvgNetFee,
+  calculateDiscountAmount,
+  calculateDiscountPct,
+  calculateGrossTaxPrepFees,
+  calculateLastYearRevenue,
+  calculateNetIncome,
+  calculateTaxPrepIncome,
+  calculateTaxRushGrossFees,
+  calculateTaxRushReturnsCount,
+  calculateTaxRushReturnsPct,
+  calculateTotalExpensesFromGross,
+  defaultTaxRushReturns,
+  normalizePriorYearMetrics,
+  round2,
+  toPct1dp,
+} from './calc.util';
+
+describe('calc.util', () => {
+  describe('round2', () => {
+    it('rounds up at half cents', () => {
+      expect(round2(10.005)).toBe(10.01);
+    });
+
+    it('rounds down below half cents', () => {
+      expect(round2(10.004)).toBe(10);
+    });
+  });
+
+  describe('toPct1dp', () => {
+    it('rounds down below .05', () => {
+      expect(toPct1dp(12.34)).toBe(12.3);
+    });
+
+    it('rounds up at .05', () => {
+      expect(toPct1dp(12.35)).toBe(12.4);
+    });
+  });
+
+  describe('calculateDiscountPct', () => {
+    it('calculates discount percentage rounded to 1 decimal', () => {
+      expect(calculateDiscountPct(206000, 6180)).toBe(3);
+    });
+
+    it('handles zero gross fees', () => {
+      expect(calculateDiscountPct(0, 500)).toBe(0);
+    });
+  });
+
+  describe('calculateDiscountAmount', () => {
+    it('calculates discount amount from pct', () => {
+      expect(calculateDiscountAmount(206000, 3)).toBe(6180);
+    });
+
+    it('handles tiny percentage values with cent rounding', () => {
+      expect(calculateDiscountAmount(999999.99, 0.1)).toBe(1000);
+    });
+  });
+
+  describe('calculateAvgNetFee', () => {
+    it('derives average net fee from totals', () => {
+      expect(calculateAvgNetFee(206000, 1680)).toBe(122.62);
+    });
+
+    it('returns 0 when returns are 0', () => {
+      expect(calculateAvgNetFee(100000, 0)).toBe(0);
+    });
+  });
+
+  describe('calculateTaxPrepIncome', () => {
+    it('subtracts explicit discounts', () => {
+      expect(calculateTaxPrepIncome(206000, 6180)).toBe(199820);
+    });
+
+    it('applies default 3% discount when none provided', () => {
+      expect(calculateTaxPrepIncome(100000)).toBe(97000);
+    });
+
+    it('returns 0 when gross fees are 0', () => {
+      expect(calculateTaxPrepIncome(0, 100)).toBe(0);
+    });
+  });
+
+  describe('calculateGrossTaxPrepFees', () => {
+    it('multiplies average fee and returns with cent rounding', () => {
+      expect(calculateGrossTaxPrepFees(125.5, 1680)).toBe(210840);
+    });
+
+    it('returns 0 when any input missing', () => {
+      expect(calculateGrossTaxPrepFees(0, 1500)).toBe(0);
+    });
+  });
+
+  describe('calculateTaxRushGrossFees', () => {
+    it('uses provided avg net fee', () => {
+      expect(calculateTaxRushGrossFees(240, 125)).toBe(30000);
+    });
+
+    it('falls back to avg net fee from gross and returns', () => {
+      expect(calculateTaxRushGrossFees(240, undefined, 206000, 1680)).toBe(29428.8);
+    });
+
+    it('handles non-integer average fees', () => {
+      expect(calculateTaxRushGrossFees(175, 123.45)).toBe(21603.75);
+    });
+  });
+
+  describe('calculateTaxRushReturnsPct', () => {
+    it('calculates percentage rounded to 1 decimal', () => {
+      expect(calculateTaxRushReturnsPct(252, 1680)).toBe(15);
+    });
+
+    it('returns 0 when total returns is 0', () => {
+      expect(calculateTaxRushReturnsPct(200, 0)).toBe(0);
+    });
+  });
+
+  describe('calculateTaxRushReturnsCount', () => {
+    it('converts percentage to count', () => {
+      expect(calculateTaxRushReturnsCount(1680, 15)).toBe(252);
+    });
+
+    it('handles fractional percentages', () => {
+      expect(calculateTaxRushReturnsCount(1600, 12.5)).toBe(200);
+    });
+  });
+
+  describe('defaultTaxRushReturns', () => {
+    it('defaults to 15% of total returns', () => {
+      expect(defaultTaxRushReturns(1680)).toBe(252);
+    });
+
+    it('handles different totals', () => {
+      expect(defaultTaxRushReturns(1000)).toBe(150);
+    });
+  });
+
+  describe('calculateLastYearRevenue', () => {
+    it('combines gross fees, discounts, and other income', () => {
+      expect(calculateLastYearRevenue(206000, 6180, 2500)).toBe(202320);
+    });
+
+    it('handles fractional cents and rounds to cents', () => {
+      expect(calculateLastYearRevenue(100000.55, 3000.12, 0.2)).toBe(97000.63);
+    });
+  });
+
+  describe('calculateTotalExpensesFromGross', () => {
+    it('returns 76% of gross tax prep fees', () => {
+      expect(calculateTotalExpensesFromGross(200000)).toBe(152000);
+    });
+
+    it('returns 0 for zero gross fees', () => {
+      expect(calculateTotalExpensesFromGross(0)).toBe(0);
+    });
+  });
+
+  describe('calculateNetIncome', () => {
+    it('subtracts expenses from revenue with cent rounding', () => {
+      expect(calculateNetIncome(202320, 150000.12)).toBe(52319.88);
+    });
+
+    it('handles zero revenue', () => {
+      expect(calculateNetIncome(0, 500)).toBe(-500);
+    });
+  });
+
+  describe('normalizePriorYearMetrics', () => {
+    it('normalizes raw metrics using calc helpers', () => {
+      expect(
+        normalizePriorYearMetrics({
+          grossFees: 206000,
+          discountAmount: 6180,
+          otherIncome: 2500,
+          expenses: 150000,
+          taxPrepReturns: 1680,
+          taxRushReturns: 240,
+          taxRushAvgNetFee: 125,
+        })
+      ).toEqual({
+        grossFees: 206000,
+        discountAmount: 6180,
+        discountPct: 3,
+        taxPrepIncome: 199820,
+        taxRushGrossFees: 30000,
+        revenue: 202320,
+        expenses: 150000,
+        netIncome: 52320,
+        avgNetFee: 122.62,
+        otherIncome: 2500,
+        taxPrepReturns: 1680,
+        taxRushReturns: 240,
+        taxRushAvgNetFee: 125,
+      });
+    });
+
+    it('falls back to avg net fee when taxRush fee missing', () => {
+      const normalized = normalizePriorYearMetrics({
+        grossFees: 206000,
+        discountAmount: 6180,
+        otherIncome: 2500,
+        expenses: 150000,
+        taxPrepReturns: 1680,
+        taxRushReturns: 240,
+      });
+
+      expect(normalized.taxRushAvgNetFee).toBe(122.62);
+      expect(normalized.taxRushGrossFees).toBe(29428.8);
+    });
+  });
+});

--- a/src/app/existing-store/shared/calc.util.ts
+++ b/src/app/existing-store/shared/calc.util.ts
@@ -1,0 +1,138 @@
+import { PriorYearMetrics, PriorYearRawMetrics } from './prior-year.models';
+
+/**
+ * Pure calculation helpers for existing-store prior-year and income-driver fields.
+ *
+ * Conventions:
+ * - Percentages use 0–100 representations (e.g., 12.5 === 12.5%).
+ * - Currency-facing results always flow through {@link round2} to avoid FP artifacts.
+ */
+
+export function round2(n: number): number {
+  return Math.round((n + Number.EPSILON) * 100) / 100;
+}
+
+export function toPct1dp(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
+export function calculateDiscountPct(grossFees: number, discountAmount: number): number {
+  if (!grossFees) {
+    return 0;
+  }
+  return toPct1dp((discountAmount / grossFees) * 100);
+}
+
+export function calculateDiscountAmount(grossFees: number, discountPct: number): number {
+  return round2(grossFees * (discountPct / 100));
+}
+
+export function calculateAvgNetFee(grossFees: number, taxPrepReturns: number): number {
+  if (!taxPrepReturns) {
+    return 0;
+  }
+  return round2(grossFees / taxPrepReturns);
+}
+
+export function calculateGrossTaxPrepFees(avgNetFee: number, taxPrepReturns: number): number {
+  if (!avgNetFee || !taxPrepReturns) {
+    return 0;
+  }
+  return round2(avgNetFee * taxPrepReturns);
+}
+
+export function calculateTaxPrepIncome(grossFees: number, discountAmount?: number): number {
+  if (!grossFees) {
+    return 0;
+  }
+
+  const appliedDiscount = discountAmount !== undefined ? round2(discountAmount) : round2(grossFees * 0.03);
+  return round2(grossFees - appliedDiscount);
+}
+
+export function calculateTaxRushGrossFees(
+  taxRushReturns: number,
+  taxRushAvgNetFee?: number,
+  grossFees?: number,
+  taxPrepReturns?: number
+): number {
+  let avg = taxRushAvgNetFee;
+
+  if (avg === undefined && grossFees !== undefined && taxPrepReturns) {
+    avg = calculateAvgNetFee(grossFees, taxPrepReturns);
+  }
+
+  if (avg === undefined) {
+    return 0;
+  }
+
+  return round2(taxRushReturns * avg);
+}
+
+export function calculateTaxRushReturnsPct(taxRushReturns: number, totalReturns: number): number {
+  if (!totalReturns) {
+    return 0;
+  }
+  return toPct1dp((taxRushReturns / totalReturns) * 100);
+}
+
+export function calculateTaxRushReturnsCount(totalReturns: number, pct: number): number {
+  return Math.round(totalReturns * (pct / 100));
+}
+
+export function defaultTaxRushReturns(totalReturns: number): number {
+  return Math.round(totalReturns * 0.15);
+}
+
+export function calculateLastYearRevenue(grossFees: number, discountAmount: number, otherIncome: number): number {
+  return round2(grossFees - discountAmount + otherIncome);
+}
+
+export function calculateTotalExpensesFromGross(grossTaxPrepFees: number): number {
+  if (!grossTaxPrepFees) {
+    return 0;
+  }
+  return round2(grossTaxPrepFees * 0.76);
+}
+
+export function calculateNetIncome(revenue: number, expenses: number): number {
+  return round2(revenue - expenses);
+}
+
+export function normalizePriorYearMetrics(raw: PriorYearRawMetrics): PriorYearMetrics {
+  const gross = Number(raw.grossFees) || 0;
+  const discountAmount = Number(raw.discountAmount) || 0;
+  const otherIncome = Number(raw.otherIncome) || 0;
+  const expenses = Number(raw.expenses) || 0;
+  const taxPrepReturns = Number(raw.taxPrepReturns) || 0;
+  const taxRushReturns = Number(raw.taxRushReturns) || 0;
+  const taxRushAvgNetFee = raw.taxRushAvgNetFee;
+
+  const discountPct = calculateDiscountPct(gross, discountAmount);
+  const avgNetFee = calculateAvgNetFee(gross, taxPrepReturns);
+  const taxPrepIncome = calculateTaxPrepIncome(gross, discountAmount);
+  const taxRushGrossFees = calculateTaxRushGrossFees(
+    taxRushReturns,
+    taxRushAvgNetFee,
+    gross,
+    taxPrepReturns
+  );
+  const revenue = calculateLastYearRevenue(gross, discountAmount, otherIncome);
+  const netIncome = calculateNetIncome(revenue, expenses);
+
+  return {
+    grossFees: round2(gross),
+    discountAmount: round2(discountAmount),
+    discountPct,
+    taxPrepIncome,
+    taxRushGrossFees,
+    revenue,
+    expenses: round2(expenses),
+    netIncome,
+    avgNetFee,
+    otherIncome: round2(otherIncome),
+    taxPrepReturns,
+    taxRushReturns,
+    taxRushAvgNetFee: round2(taxRushAvgNetFee ?? avgNetFee),
+  };
+}

--- a/src/app/existing-store/shared/fields.dictionary.ts
+++ b/src/app/existing-store/shared/fields.dictionary.ts
@@ -1,0 +1,198 @@
+export type FieldKey =
+  | 'avgNetFee'
+  | 'taxPrepReturns'
+  | 'taxRushReturns'
+  | 'taxRushPercentage'
+  | 'taxRushFee'
+  | 'grossTaxPrepFees'
+  | 'grossTaxRushFees'
+  | 'discountsAmt'
+  | 'discountsPct'
+  | 'netTaxPrepFees'
+  | 'otherIncome'
+  | 'totalExpenses'
+  | 'lastYearGrossFees'
+  | 'lastYearExpenses'
+  | 'lastYearReturns'
+  | 'expectedGrowthPct'
+  | 'handlesTaxRush'
+  | 'lastYearRevenue'
+  | 'netIncome';
+
+type FieldType = 'number' | 'money' | 'percent' | 'boolean' | 'text';
+
+type FieldUnit = '$' | '%' | '#';
+
+export interface FieldSpec {
+  key: FieldKey;
+  label: string;
+  type: FieldType;
+  unit?: FieldUnit;
+  validators?: {
+    required?: boolean;
+    min?: number;
+    max?: number;
+    step?: number;
+    pattern?: string;
+  };
+  deriveFrom?: FieldKey[];
+  aliases?: string[];
+  help?: string;
+}
+
+export const FIELDS: Record<FieldKey, FieldSpec> = {
+  avgNetFee: {
+    key: 'avgNetFee',
+    label: 'Average Net Fee',
+    type: 'money',
+    unit: '$',
+    validators: { required: true, min: 50, max: 500, step: 1 },
+    help: 'Average net fee per standard tax return.',
+  },
+  taxPrepReturns: {
+    key: 'taxPrepReturns',
+    label: 'Tax Prep Returns',
+    type: 'number',
+    unit: '#',
+    validators: { required: true, min: 100, max: 10000, step: 1 },
+    help: 'Projected number of tax prep returns.',
+  },
+  taxRushReturns: {
+    key: 'taxRushReturns',
+    label: 'TaxRush Returns',
+    type: 'number',
+    unit: '#',
+    validators: { min: 0, max: 10000, step: 1 },
+    help: 'TaxRush return volume when the product is enabled.',
+  },
+  taxRushPercentage: {
+    key: 'taxRushPercentage',
+    label: 'TaxRush % of Returns',
+    type: 'percent',
+    unit: '%',
+    validators: { min: 0, max: 100, step: 0.1 },
+    deriveFrom: ['taxRushReturns', 'taxPrepReturns'],
+    help: 'Share of total returns that flow through TaxRush.',
+  },
+  taxRushFee: {
+    key: 'taxRushFee',
+    label: 'TaxRush Average Net Fee',
+    type: 'money',
+    unit: '$',
+    validators: { min: 0, max: 500, step: 1 },
+    help: 'Average fee collected per TaxRush return.',
+  },
+  grossTaxPrepFees: {
+    key: 'grossTaxPrepFees',
+    label: 'Gross Tax Prep Fees',
+    type: 'money',
+    unit: '$',
+    deriveFrom: ['avgNetFee', 'taxPrepReturns'],
+    help: 'Auto-calculated: Average Net Fee × Tax Prep Returns.',
+  },
+  grossTaxRushFees: {
+    key: 'grossTaxRushFees',
+    label: 'Gross TaxRush Fees',
+    type: 'money',
+    unit: '$',
+    deriveFrom: ['taxRushReturns', 'taxRushFee', 'avgNetFee', 'taxPrepReturns'],
+    help: 'Auto-calculated from TaxRush volume and fees.',
+  },
+  discountsAmt: {
+    key: 'discountsAmt',
+    label: 'Customer Discounts ($)',
+    type: 'money',
+    unit: '$',
+    deriveFrom: ['grossTaxPrepFees', 'discountsPct'],
+    help: 'Dollar value of discounts applied to gross fees.',
+  },
+  discountsPct: {
+    key: 'discountsPct',
+    label: 'Customer Discounts (%)',
+    type: 'percent',
+    unit: '%',
+    validators: { min: 0, max: 100, step: 0.1 },
+    help: 'Discount percentage applied to gross fees.',
+  },
+  netTaxPrepFees: {
+    key: 'netTaxPrepFees',
+    label: 'Net Tax Prep Fees',
+    type: 'money',
+    unit: '$',
+    deriveFrom: ['grossTaxPrepFees', 'discountsAmt'],
+    help: 'Gross fees minus customer discounts.',
+  },
+  otherIncome: {
+    key: 'otherIncome',
+    label: 'Other Income',
+    type: 'money',
+    unit: '$',
+    validators: { min: 0, step: 1 },
+    help: 'Additional revenue streams beyond core tax prep.',
+  },
+  totalExpenses: {
+    key: 'totalExpenses',
+    label: 'Total Expenses',
+    type: 'money',
+    unit: '$',
+    deriveFrom: ['grossTaxPrepFees'],
+    help: 'Target expenses using the 76% industry benchmark.',
+  },
+  lastYearGrossFees: {
+    key: 'lastYearGrossFees',
+    label: 'Prior-Year Gross Fees',
+    type: 'money',
+    unit: '$',
+    validators: { min: 0, step: 1 },
+    aliases: ['lastYearRevenue'],
+    help: 'Recorded gross fees from the prior season.',
+  },
+  lastYearExpenses: {
+    key: 'lastYearExpenses',
+    label: 'Prior-Year Expenses',
+    type: 'money',
+    unit: '$',
+    validators: { min: 0, step: 1 },
+    help: 'Recorded expenses from the prior season.',
+  },
+  lastYearReturns: {
+    key: 'lastYearReturns',
+    label: 'Prior-Year Returns',
+    type: 'number',
+    unit: '#',
+    validators: { min: 0, max: 10000, step: 1 },
+    help: 'Return volume filed in the prior season.',
+  },
+  expectedGrowthPct: {
+    key: 'expectedGrowthPct',
+    label: 'Expected Growth %',
+    type: 'percent',
+    unit: '%',
+    validators: { min: -50, max: 100, step: 0.5 },
+    help: 'Growth assumption for forecasting future returns and fees.',
+  },
+  handlesTaxRush: {
+    key: 'handlesTaxRush',
+    label: 'Handles TaxRush',
+    type: 'boolean',
+    help: 'Whether the store offers the TaxRush product.',
+  },
+  lastYearRevenue: {
+    key: 'lastYearRevenue',
+    label: 'Prior-Year Revenue',
+    type: 'money',
+    unit: '$',
+    validators: { min: 0, step: 1 },
+    aliases: ['lastYearGrossFees'],
+    deriveFrom: ['lastYearGrossFees'],
+    help: 'Gross fees minus discounts plus other income for the prior season.',
+  },
+  netIncome: {
+    key: 'netIncome',
+    label: 'Net Income',
+    type: 'money',
+    unit: '$',
+    deriveFrom: ['lastYearRevenue', 'lastYearExpenses'],
+    help: 'Revenue minus expenses for the selected season.',
+  },
+};

--- a/src/app/existing-store/shared/prior-year.models.ts
+++ b/src/app/existing-store/shared/prior-year.models.ts
@@ -1,0 +1,25 @@
+export interface PriorYearRawMetrics {
+  grossFees?: number;
+  discountAmount?: number;
+  otherIncome?: number;
+  expenses?: number;
+  taxPrepReturns?: number;
+  taxRushReturns?: number;
+  taxRushAvgNetFee?: number;
+}
+
+export interface PriorYearMetrics {
+  grossFees: number;
+  discountAmount: number;
+  discountPct: number;
+  taxPrepIncome: number;
+  taxRushGrossFees: number;
+  revenue: number;
+  expenses: number;
+  netIncome: number;
+  avgNetFee: number;
+  otherIncome: number;
+  taxPrepReturns: number;
+  taxRushReturns: number;
+  taxRushAvgNetFee: number;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,9 @@
 import { bootstrapApplication } from '@angular/platform-browser';
+import { provideRouter } from '@angular/router';
 import { AppComponent } from './app/app';
+import { routes } from './app/app.routes';
 
 bootstrapApplication(AppComponent, {
-  providers: []
+  providers: [provideRouter(routes)]
 })
   .catch((err) => console.error(err));


### PR DESCRIPTION
## Summary
- drive prior-year form inputs and summary metrics from the shared field dictionary, including reusable config for units and formatting
- surface dictionary-provided units in the income drivers UI to eliminate hard-coded currency and percent labels
- extend the field dictionary and expedition logs with a net income spec plus refreshed citations for the dictionary-driven templates

## Testing
- npm test -- --watch=false *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8455e07088327a0b139d75a8867b8