### PR TITLE
Add schema-driven income driver form

### DIFF
--- a/src/app/components/income-drivers/income-drivers.component.ts
+++ b/src/app/components/income-drivers/income-drivers.component.ts
@@ -1,631 +1,264 @@
-import { Component, Input, Output, EventEmitter, OnInit, OnDestroy } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnChanges, OnDestroy, SimpleChanges, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule, FormBuilder, FormGroup, FormControl } from '@angular/forms';
-import { Subject, takeUntil, debounceTime, distinctUntilChanged } from 'rxjs';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Subscription } from 'rxjs';
+import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 
-import { Region } from '../../models/wizard.models';
-import { ExpenseField, getFieldsForRegion } from '../../models/expense.models';
-import { formatCurrency, formatPercentage } from '../../utils/calculation.utils';
+import { PriorYearMetrics } from '../prior-year-performance/prior-year-performance.component';
+import { schemaFor, type GoalsSchemaEntry, type Mode } from '../../existing-store/income-drivers/goals.config';
+import { FIELDS, type FieldKey, type FieldSpec } from '../../existing-store/shared/fields.dictionary';
+import * as Calc from '../../existing-store/shared/calc.util';
 
-// Income driver field definitions following FIELDS pattern
-interface IncomeDriverField {
-  id: string;
-  label: string;
-  description?: string;
-  type: 'currency' | 'number' | 'percentage';
-  min: number;
-  max: number;
-  step: number;
-  defaultValue: number;
-  regionSpecific?: 'US' | 'CA' | 'both';
-  conditional?: string; // Condition for field visibility
-}
-
-// FIELDS configuration for income drivers
-const INCOME_DRIVER_FIELDS: IncomeDriverField[] = [
-  {
-    id: 'avgNetFee',
-    label: 'Average Net Fee',
-    description: 'Your target average net fee per return',
-    type: 'currency',
-    min: 50,
-    max: 500,
-    step: 1,
-    defaultValue: 125
-  },
-  {
-    id: 'taxPrepReturns',
-    label: 'Tax Prep Returns',
-    description: 'Your target number of tax returns',
-    type: 'number',
-    min: 100,
-    max: 10000,
-    step: 1,
-    defaultValue: 1600
-  },
-  {
-    id: 'taxRushReturns',
-    label: 'TaxRush Returns',
-    description: 'Number of TaxRush returns (Canada only)',
-    type: 'number',
-    min: 0,
-    max: 1000,
-    step: 1,
-    defaultValue: 0,
-    regionSpecific: 'CA',
-    conditional: 'handlesTaxRush'
-  },
-  {
-    id: 'discountsPct',
-    label: 'Customer Discounts',
-    description: 'Percentage discount given to customers',
-    type: 'percentage',
-    min: 0,
-    max: 50,
-    step: 0.1,
-    defaultValue: 3
-  },
-  {
-    id: 'otherIncome',
-    label: 'Other Income',
-    description: 'Additional revenue sources (e.g., notary services, business consulting)',
-    type: 'currency',
-    min: 0,
-    max: 50000,
-    step: 100,
-    defaultValue: 0,
-    conditional: 'hasOtherIncome'
-  }
-];
-
-// Schema generation for dynamic forms
-function schemaFor(region: Region, conditions: Record<string, boolean> = {}): IncomeDriverField[] {
-  return INCOME_DRIVER_FIELDS.filter(field => {
-    // Region filtering
-    if (field.regionSpecific && field.regionSpecific !== region && field.regionSpecific !== 'both') {
-      return false;
-    }
-    
-    // Conditional filtering
-    if (field.conditional) {
-      return conditions[field.conditional] === true;
-    }
-    
-    return true;
-  });
-}
-
-interface IncomeDriverData {
-  avgNetFee: number;
-  taxPrepReturns: number;
-  taxRushReturns: number;
-  discountsPct: number;
-  otherIncome: number;
-  handlesTaxRush: boolean;
-  hasOtherIncome: boolean;
-}
+const DEFAULT_FIELD_VALUES: Partial<Record<FieldKey, number>> = {
+  avgNetFee: 0,
+  taxPrepReturns: 0,
+  grossTaxPrepFees: 0,
+  discountsPct: 0,
+  discountsAmt: 0,
+  netTaxPrepIncome: 0,
+  taxRushReturns: 0,
+  taxRushPercentage: 0,
+  taxRushFee: 0,
+  taxRushIncome: 0,
+  otherIncome: 0,
+  totalRevenue: 0
+};
 
 @Component({
   selector: 'app-income-drivers',
   standalone: true,
   imports: [CommonModule, ReactiveFormsModule],
   template: `
-    <div class="income-drivers-container">
-      <div class="section-header">
-        <h3>💰 Income Drivers</h3>
-        <p class="section-description">Configure your income targets and revenue sources</p>
-      </div>
+    <section class="income-drivers">
+      <header class="flex items-center justify-between mb-3">
+        <h2 class="text-lg font-semibold">{{ displayTitle || 'Income Drivers' }}</h2>
+        <small class="opacity-70">{{ mode | uppercase }} • {{ region }} • {{ storeType }}</small>
+      </header>
 
-      <form [formGroup]="incomeForm" class="income-drivers-form">
-        <div class="fields-container">
-          <div *ngFor="let field of visibleFields; trackBy: trackByFieldId" 
-               class="field-group" 
-               [ngClass]="getFieldCssClass(field)">
-            
-            <!-- Field Label and Description -->
-            <div class="field-header">
-              <label [for]="field.id" class="field-label">
-                {{ field.label }}
-                <span *ngIf="field.description" 
-                      class="help-button" 
-                      [title]="field.description">
-                  ℹ️
-                </span>
-              </label>
-              
-              <!-- Calculated Display (for derived values) -->
-              <div *ngIf="getDerivedValue(field.id) !== null" class="derived-value">
-                {{ formatFieldValue(getDerivedValue(field.id)!, field.type) }}
-              </div>
-            </div>
+      <form [formGroup]="form" class="grid gap-3">
+        <!-- Render controls from the active schema -->
+        <ng-container *ngFor="let key of visibleKeys">
+          <label class="flex flex-col gap-1">
+            <span class="text-sm">
+              {{ fieldSpec(key).label }}
+              <ng-container *ngIf="fieldSpec(key).unit">({{ fieldSpec(key).unit }})</ng-container>
+            </span>
 
-            <!-- Input Controls -->
-            <div class="input-controls">
-              <!-- Currency/Number Input -->
-              <div class="input-group">
-                <span *ngIf="field.type === 'currency'" class="input-prefix">$</span>
-                <span *ngIf="field.type === 'number'" class="input-prefix">#</span>
-                
-                <input
-                  [id]="field.id"
-                  [formControlName]="field.id"
-                  type="number"
-                  [min]="field.min"
-                  [max]="field.max"
-                  [step]="field.step"
-                  [placeholder]="field.defaultValue.toString()"
-                  class="field-input"
-                  [class.currency-input]="field.type === 'currency'"
-                  [class.number-input]="field.type === 'number'"
-                  [class.percentage-input]="field.type === 'percentage'">
-                
-                <span *ngIf="field.type === 'percentage'" class="input-suffix">%</span>
-              </div>
+            <input
+              class="border rounded p-2"
+              [attr.inputmode]="fieldSpec(key).type === 'number' || fieldSpec(key).type === 'money' || fieldSpec(key).type === 'percent' ? 'decimal' : 'text'"
+              [readonly]="isDerived(key)"
+              [formControlName]="key" />
 
-              <!-- Dollar Equivalent for Percentage Fields -->
-              <div *ngIf="field.type === 'percentage' && field.id === 'discountsPct'" 
-                   class="dollar-equivalent">
-                <span class="equals-symbol">=</span>
-                <div class="input-group">
-                  <span class="input-prefix">$</span>
-                  <input
-                    type="number"
-                    [value]="getDiscountDollarAmount()"
-                    (input)="onDiscountDollarChange($event)"
-                    class="field-input dollar-input"
-                    placeholder="0">
-                </div>
-              </div>
-            </div>
+            <em class="text-xs opacity-70" *ngIf="fieldSpec(key).help">
+              {{ fieldSpec(key).help }}
+            </em>
 
-            <!-- Range Slider -->
-            <input *ngIf="showSliderFor(field)"
-                   type="range"
-                   [formControlName]="field.id"
-                   [min]="field.min"
-                   [max]="getSliderMax(field)"
-                   [step]="field.step"
-                   class="field-slider">
-
-            <!-- Field Description -->
-            <p *ngIf="field.description" class="field-description">
-              {{ field.description }}
-            </p>
-          </div>
-        </div>
-
-        <!-- Calculated Revenue Summary -->
-        <div class="revenue-summary" *ngIf="calculatedValues.totalRevenue > 0">
-          <div class="summary-row">
-            <span class="summary-label">Gross Tax Prep Fees:</span>
-            <span class="summary-value">{{ formatCurrency(calculatedValues.grossFees) }}</span>
-          </div>
-          <div class="summary-row">
-            <span class="summary-label">Less: Customer Discounts:</span>
-            <span class="summary-value negative">{{ formatCurrency(calculatedValues.discounts) }}</span>
-          </div>
-          <div class="summary-row">
-            <span class="summary-label">Net Tax Prep Income:</span>
-            <span class="summary-value">{{ formatCurrency(calculatedValues.taxPrepIncome) }}</span>
-          </div>
-          <div *ngIf="calculatedValues.taxRushIncome > 0" class="summary-row">
-            <span class="summary-label">TaxRush Income:</span>
-            <span class="summary-value">{{ formatCurrency(calculatedValues.taxRushIncome) }}</span>
-          </div>
-          <div *ngIf="calculatedValues.otherIncome > 0" class="summary-row">
-            <span class="summary-label">Other Income:</span>
-            <span class="summary-value">{{ formatCurrency(calculatedValues.otherIncome) }}</span>
-          </div>
-          <div class="summary-row total-row">
-            <span class="summary-label">Total Revenue:</span>
-            <span class="summary-value">{{ formatCurrency(calculatedValues.totalRevenue) }}</span>
-          </div>
-        </div>
+            <span class="text-xs text-red-600" *ngIf="form.get(key)?.invalid && (form.get(key)?.touched || form.get(key)?.dirty)">
+              Invalid value
+            </span>
+          </label>
+        </ng-container>
       </form>
-    </div>
-  `,
-  styles: [`
-    .income-drivers-container {
-      background: #fafafa;
-      border: 1px solid #d1d5db;
-      border-radius: 8px;
-      padding: 1.5rem;
-      margin-bottom: 1.5rem;
-    }
-
-    .section-header h3 {
-      display: flex;
-      align-items: center;
-      margin-bottom: 0.5rem;
-      font-weight: 600;
-      font-size: 1.1rem;
-      color: #059669;
-      border-bottom: 2px solid #059669;
-      padding-bottom: 0.25rem;
-    }
-
-    .section-description {
-      color: #6b7280;
-      font-size: 0.875rem;
-      margin: 0 0 1.5rem 0;
-    }
-
-    .fields-container {
-      display: flex;
-      flex-direction: column;
-      gap: 1rem;
-    }
-
-    .field-group {
-      background: white;
-      border: 1px solid #e5e7eb;
-      border-radius: 6px;
-      padding: 1rem;
-    }
-
-    .field-group.taxrush-field {
-      border: 2px solid #3b82f6;
-      background-color: #f8fafc;
-    }
-
-    .field-header {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      margin-bottom: 0.5rem;
-    }
-
-    .field-label {
-      font-size: 0.9rem;
-      font-weight: 500;
-      color: #374151;
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-    }
-
-    .help-button {
-      background: none;
-      border: none;
-      color: #6b7280;
-      cursor: help;
-      font-size: 0.8rem;
-      padding: 0;
-    }
-
-    .derived-value {
-      font-size: 0.875rem;
-      color: #059669;
-      font-weight: 500;
-      padding: 0.25rem 0.5rem;
-      background: #f0fdf4;
-      border-radius: 4px;
-    }
-
-    .input-controls {
-      display: flex;
-      align-items: center;
-      gap: 0.75rem;
-      margin-bottom: 0.5rem;
-    }
-
-    .input-group {
-      display: flex;
-      align-items: center;
-      position: relative;
-    }
-
-    .input-prefix,
-    .input-suffix {
-      position: absolute;
-      color: #6b7280;
-      font-size: 0.8rem;
-      font-weight: 500;
-      z-index: 1;
-    }
-
-    .input-prefix {
-      left: 0.75rem;
-    }
-
-    .input-suffix {
-      right: 0.75rem;
-    }
-
-    .field-input {
-      padding: 0.5rem;
-      border: 1px solid #d1d5db;
-      border-radius: 4px;
-      font-size: 0.9rem;
-      width: 120px;
-      text-align: right;
-    }
-
-    .currency-input,
-    .number-input {
-      padding-left: 1.5rem;
-    }
-
-    .percentage-input {
-      padding-right: 1.5rem;
-    }
-
-    .field-input:focus {
-      outline: none;
-      border-color: #3b82f6;
-      box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
-    }
-
-    .dollar-equivalent {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-    }
-
-    .equals-symbol {
-      color: #6b7280;
-      font-size: 0.8rem;
-    }
-
-    .dollar-input {
-      background-color: #f9fafb;
-      width: 100px;
-    }
-
-    .field-slider {
-      width: 100%;
-      margin: 0.5rem 0;
-    }
-
-    .field-description {
-      font-size: 0.75rem;
-      color: #6b7280;
-      margin: 0.25rem 0 0 0;
-      line-height: 1.4;
-    }
-
-    .revenue-summary {
-      margin-top: 1.5rem;
-      padding: 1rem;
-      background: #f0f9ff;
-      border: 1px solid #0ea5e9;
-      border-radius: 6px;
-    }
-
-    .summary-row {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding: 0.25rem 0;
-    }
-
-    .summary-label {
-      font-size: 0.875rem;
-      color: #374151;
-    }
-
-    .summary-value {
-      font-weight: 500;
-      color: #374151;
-    }
-
-    .summary-value.negative {
-      color: #dc2626;
-    }
-
-    .total-row {
-      border-top: 1px solid #0ea5e9;
-      padding-top: 0.5rem;
-      margin-top: 0.5rem;
-    }
-
-    .total-row .summary-label,
-    .total-row .summary-value {
-      font-weight: 600;
-      font-size: 1rem;
-      color: #0369a1;
-    }
-  `]
+    </section>
+  `
 })
-export class IncomeDriversComponent implements OnInit, OnDestroy {
-  @Input() region: Region = 'US';
-  @Input() initialData: Partial<IncomeDriverData> = {};
-  @Input() handlesTaxRush: boolean = false;
-  @Input() hasOtherIncome: boolean = false;
+export class IncomeDriversComponent implements OnChanges, OnDestroy {
+  private fb = inject(FormBuilder);
 
-  @Output() dataChange = new EventEmitter<IncomeDriverData>();
-  @Output() calculatedValues = new EventEmitter<any>();
+  // Inputs selected by the parent shell
+  @Input() mode: Mode = 'new';
+  @Input() region!: string;
+  @Input() storeType!: string;
+  @Input() priorYear?: PriorYearMetrics;
+  @Input() displayTitle?: string;
 
-  incomeForm: FormGroup;
-  visibleFields: IncomeDriverField[] = [];
-  
-  // Calculated values for display (derived via calc.util pattern)
-  calculatedValues = {
-    grossFees: 0,
-    discounts: 0,
-    taxPrepIncome: 0,
-    taxRushIncome: 0,
-    otherIncome: 0,
-    totalRevenue: 0
+  // Emit a simple form state snapshot upward
+  @Output() formState = new EventEmitter<{ value: any; valid: boolean; touched: boolean }>();
+
+  form: FormGroup = this.fb.group({});
+  private currentSchema: GoalsSchemaEntry | null = null;
+  private valueChangesSub?: Subscription;
+
+  // Cache of visible keys from the schema (order preserved)
+  visibleKeys: FieldKey[] = [];
+
+  ngOnChanges(_changes: SimpleChanges): void {
+    // Rebuild schema & form whenever the scenario changes
+    this.currentSchema = schemaFor(this.mode, this.region, this.storeType);
+    this.visibleKeys = [...(this.currentSchema?.fields ?? [])];
+
+    this.rebuildForm();
+
+    // Recompute derived fields once at scenario change (from priorYear if present)
+    this.applyDerivedFromPriorYear();
+  }
+
+  ngOnDestroy(): void {
+    this.valueChangesSub?.unsubscribe();
+  }
+
+  /** Build Reactive Form controls from dictionary + schema */
+  private rebuildForm(): void {
+    const group: Record<string, any> = {};
+
+    for (const key of this.visibleKeys) {
+      const spec = FIELDS[key];
+      const validators = this.toAngularValidators(spec);
+      const initial = this.initialValueFor(key);
+      group[key] = [{ value: initial, disabled: this.isDerived(key) }, validators];
+    }
+
+    this.form = this.fb.group(group);
+
+    if (this.valueChangesSub) {
+      this.valueChangesSub.unsubscribe();
+    }
+
+    this.valueChangesSub = this.form.valueChanges
+      .pipe(
+        debounceTime(120),
+        distinctUntilChanged((prev, curr) => JSON.stringify(prev) === JSON.stringify(curr))
+      )
+      .subscribe(() => {
+        this.updateDerivedFields();
+        this.emitState();
+      });
+
+    this.updateDerivedFields();
+    this.emitState();
+  }
+
+  /** Convert our FieldSpec validators into Angular Validators[] */
+  private toAngularValidators(spec: FieldSpec) {
+    const v = spec.validators || {};
+    const arr = [];
+    if (v.required) arr.push(Validators.required);
+    if (typeof v.min === 'number') arr.push(Validators.min(v.min));
+    if (typeof v.max === 'number') arr.push(Validators.max(v.max));
+    if (v.pattern) arr.push(Validators.pattern(v.pattern));
+    // NOTE: step is a UI concern; consider custom validator if needed.
+    return arr;
+  }
+
+  /** Seed initial value; can draw from priorYear for certain keys */
+  private initialValueFor(key: FieldKey) {
+    if (this.priorYear && key in this.priorYear) {
+      const value = this.priorYear[key as keyof PriorYearMetrics];
+      if (value !== undefined && value !== null) {
+        return value;
+      }
+    }
+
+    if (key in DEFAULT_FIELD_VALUES) {
+      return DEFAULT_FIELD_VALUES[key as keyof typeof DEFAULT_FIELD_VALUES] ?? null;
+    }
+
+    return null;
+  }
+
+  /** Determine if a field is read-only derived */
+  isDerived = (key: FieldKey) => {
+    const spec = FIELDS[key];
+    return !!spec.deriveFrom && spec.deriveFrom.length > 0;
   };
 
-  private destroy$ = new Subject<void>();
+  /** Lookup FieldSpec quickly in template */
+  fieldSpec = (key: FieldKey) => FIELDS[key];
 
-  constructor(private fb: FormBuilder) {
-    this.incomeForm = this.createForm();
-  }
+  /** Compute all derived fields using calc.util and setValue without emitting loops */
+  private updateDerivedFields(): void {
+    if (!this.form) return;
 
-  ngOnInit() {
-    this.updateVisibleFields();
-    this.initializeFormValues();
-    this.setupValueChangeHandlers();
-    this.calculateDerivedValues();
-  }
+    const derivedKeys = this.visibleKeys.filter(k => this.isDerived(k));
+    const handlesTaxRush = this.visibleKeys.includes('taxRushReturns');
 
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
-  }
+    for (const key of derivedKeys) {
+      let computed: number | null = null;
 
-  private createForm(): FormGroup {
-    const formControls: Record<string, FormControl> = {};
-    
-    INCOME_DRIVER_FIELDS.forEach(field => {
-      formControls[field.id] = new FormControl(
-        this.initialData[field.id as keyof IncomeDriverData] ?? field.defaultValue
-      );
-    });
-
-    return this.fb.group(formControls);
-  }
-
-  private updateVisibleFields() {
-    const conditions = {
-      handlesTaxRush: this.handlesTaxRush,
-      hasOtherIncome: this.hasOtherIncome
-    };
-    
-    this.visibleFields = schemaFor(this.region, conditions);
-  }
-
-  private initializeFormValues() {
-    this.visibleFields.forEach(field => {
-      const currentValue = this.incomeForm.get(field.id)?.value;
-      if (currentValue === null || currentValue === undefined) {
-        this.incomeForm.get(field.id)?.setValue(field.defaultValue);
+      switch (key) {
+        case 'grossTaxPrepFees': {
+          computed = Calc.calculateGrossTaxPrepFees(
+            this.form.get('avgNetFee')?.value,
+            this.form.get('taxPrepReturns')?.value,
+            this.form.get('taxRushReturns')?.value,
+            { region: this.region, handlesTaxRush }
+          );
+          break;
+        }
+        case 'discountsAmt': {
+          computed = Calc.calculateDiscountAmount(
+            this.form.get('grossTaxPrepFees')?.value,
+            this.form.get('discountsPct')?.value
+          );
+          break;
+        }
+        case 'netTaxPrepIncome': {
+          computed = Calc.calculateNetTaxPrepIncome(
+            this.form.get('grossTaxPrepFees')?.value,
+            this.form.get('discountsAmt')?.value
+          );
+          break;
+        }
+        case 'taxRushPercentage': {
+          computed = Calc.calculateTaxRushPercentage(
+            this.form.get('taxPrepReturns')?.value,
+            this.form.get('taxRushReturns')?.value
+          );
+          break;
+        }
+        case 'taxRushIncome': {
+          computed = Calc.calculateTaxRushIncome(
+            this.form.get('taxRushReturns')?.value,
+            this.form.get('taxRushFee')?.value
+          );
+          break;
+        }
+        case 'totalRevenue': {
+          const netIncome = this.form.get('netTaxPrepIncome')?.value;
+          const rushIncome = handlesTaxRush ? this.form.get('taxRushIncome')?.value : 0;
+          const otherIncome = this.form.get('otherIncome')?.value;
+          computed = Calc.calculateTotalRevenue(netIncome, rushIncome, otherIncome);
+          break;
+        }
       }
+
+      if (computed === null || Number.isNaN(computed)) continue;
+
+      const ctrl = this.form.get(key);
+      if (ctrl) {
+        ctrl.setValue(computed, { emitEvent: false });
+      }
+    }
+  }
+
+  /** Optional: initialize derived fields from priorYear snapshot */
+  private applyDerivedFromPriorYear(): void {
+    if (!this.priorYear) {
+      this.updateDerivedFields();
+      this.emitState();
+      return;
+    }
+
+    for (const key of this.visibleKeys) {
+      const ctrl = this.form.get(key);
+      if (!ctrl) continue;
+
+      const priorValue = this.priorYear[key as keyof PriorYearMetrics];
+      if (priorValue !== undefined && priorValue !== null) {
+        ctrl.setValue(priorValue, { emitEvent: false });
+      }
+    }
+
+    this.updateDerivedFields();
+    this.emitState();
+  }
+
+  private emitState(): void {
+    this.formState.emit({
+      value: this.form.getRawValue(),
+      valid: this.form.valid,
+      touched: this.form.touched
     });
   }
-
-  private setupValueChangeHandlers() {
-    // Debounced valueChanges for calc.util integration
-    this.incomeForm.valueChanges
-      .pipe(
-        debounceTime(300),
-        distinctUntilChanged((prev, curr) => JSON.stringify(prev) === JSON.stringify(curr)),
-        takeUntil(this.destroy$)
-      )
-      .subscribe(values => {
-        this.calculateDerivedValues();
-        this.emitDataChange();
-      });
-  }
-
-  // Calc.util integration - derive calculated values
-  private calculateDerivedValues() {
-    const formValues = this.incomeForm.value;
-    
-    // Core calculations following calc.util pattern
-    const grossFees = (formValues.avgNetFee || 0) * (formValues.taxPrepReturns || 0);
-    const discounts = grossFees * ((formValues.discountsPct || 0) / 100);
-    const taxPrepIncome = grossFees - discounts;
-    
-    // TaxRush income (Canada only)
-    const taxRushIncome = this.region === 'CA' && this.handlesTaxRush ? 
-      (formValues.taxRushReturns || 0) * (formValues.avgNetFee || 0) * 0.15 : 0;
-    
-    const otherIncome = this.hasOtherIncome ? (formValues.otherIncome || 0) : 0;
-    const totalRevenue = taxPrepIncome + taxRushIncome + otherIncome;
-
-    // Update calculated values
-    this.calculatedValues = {
-      grossFees,
-      discounts,
-      taxPrepIncome,
-      taxRushIncome,
-      otherIncome,
-      totalRevenue
-    };
-
-    // Emit calculated values for parent components
-    this.calculatedValues.emit(this.calculatedValues);
-  }
-
-  private emitDataChange() {
-    const formData = this.incomeForm.value;
-    const data: IncomeDriverData = {
-      avgNetFee: formData.avgNetFee || 0,
-      taxPrepReturns: formData.taxPrepReturns || 0,
-      taxRushReturns: formData.taxRushReturns || 0,
-      discountsPct: formData.discountsPct || 0,
-      otherIncome: formData.otherIncome || 0,
-      handlesTaxRush: this.handlesTaxRush,
-      hasOtherIncome: this.hasOtherIncome
-    };
-
-    this.dataChange.emit(data);
-  }
-
-  // Template helper methods
-  trackByFieldId(index: number, field: IncomeDriverField): string {
-    return field.id;
-  }
-
-  getFieldCssClass(field: IncomeDriverField): string {
-    if (field.regionSpecific === 'CA' && field.id === 'taxRushReturns') {
-      return 'taxrush-field';
-    }
-    return '';
-  }
-
-  getDerivedValue(fieldId: string): number | null {
-    // Return derived/calculated values for display
-    switch (fieldId) {
-      case 'grossTaxPrepFees':
-        return this.calculatedValues.grossFees;
-      case 'netTaxPrepIncome':
-        return this.calculatedValues.taxPrepIncome;
-      default:
-        return null;
-    }
-  }
-
-  formatFieldValue(value: number, type: string): string {
-    switch (type) {
-      case 'currency':
-        return formatCurrency(value);
-      case 'percentage':
-        return formatPercentage(value);
-      default:
-        return value.toString();
-    }
-  }
-
-  showSliderFor(field: IncomeDriverField): boolean {
-    // Show sliders for main driver fields
-    return ['avgNetFee', 'taxPrepReturns', 'discountsPct'].includes(field.id);
-  }
-
-  getSliderMax(field: IncomeDriverField): number {
-    // Adjust slider max for better UX
-    switch (field.id) {
-      case 'taxPrepReturns':
-        return Math.min(field.max, 5000); // Cap slider at 5000 for better granularity
-      case 'discountsPct':
-        return Math.min(field.max, 25); // Cap discounts at 25% for slider
-      default:
-        return field.max;
-    }
-  }
-
-  getDiscountDollarAmount(): number {
-    const discountsPct = this.incomeForm.get('discountsPct')?.value || 0;
-    return this.calculatedValues.grossFees * (discountsPct / 100);
-  }
-
-  onDiscountDollarChange(event: Event) {
-    const target = event.target as HTMLInputElement;
-    const dollarAmount = parseFloat(target.value) || 0;
-    
-    if (this.calculatedValues.grossFees > 0) {
-      const newPercentage = (dollarAmount / this.calculatedValues.grossFees) * 100;
-      const cappedPercentage = Math.max(0, Math.min(50, newPercentage));
-      
-      this.incomeForm.get('discountsPct')?.setValue(cappedPercentage, { emitEvent: true });
-    }
-  }
-
-  // Expose utility functions to template
-  formatCurrency = formatCurrency;
-  formatPercentage = formatPercentage;
 }

--- a/src/app/components/income-drivers/legacy-income-drivers.component.ts
+++ b/src/app/components/income-drivers/legacy-income-drivers.component.ts
@@ -1,0 +1,631 @@
+import { Component, Input, Output, EventEmitter, OnInit, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, FormGroup, FormControl } from '@angular/forms';
+import { Subject, takeUntil, debounceTime, distinctUntilChanged } from 'rxjs';
+
+import { Region } from '../../models/wizard.models';
+import { ExpenseField, getFieldsForRegion } from '../../models/expense.models';
+import { formatCurrency, formatPercentage } from '../../utils/calculation.utils';
+
+// Income driver field definitions following FIELDS pattern
+interface IncomeDriverField {
+  id: string;
+  label: string;
+  description?: string;
+  type: 'currency' | 'number' | 'percentage';
+  min: number;
+  max: number;
+  step: number;
+  defaultValue: number;
+  regionSpecific?: 'US' | 'CA' | 'both';
+  conditional?: string; // Condition for field visibility
+}
+
+// FIELDS configuration for income drivers
+const INCOME_DRIVER_FIELDS: IncomeDriverField[] = [
+  {
+    id: 'avgNetFee',
+    label: 'Average Net Fee',
+    description: 'Your target average net fee per return',
+    type: 'currency',
+    min: 50,
+    max: 500,
+    step: 1,
+    defaultValue: 125
+  },
+  {
+    id: 'taxPrepReturns',
+    label: 'Tax Prep Returns',
+    description: 'Your target number of tax returns',
+    type: 'number',
+    min: 100,
+    max: 10000,
+    step: 1,
+    defaultValue: 1600
+  },
+  {
+    id: 'taxRushReturns',
+    label: 'TaxRush Returns',
+    description: 'Number of TaxRush returns (Canada only)',
+    type: 'number',
+    min: 0,
+    max: 1000,
+    step: 1,
+    defaultValue: 0,
+    regionSpecific: 'CA',
+    conditional: 'handlesTaxRush'
+  },
+  {
+    id: 'discountsPct',
+    label: 'Customer Discounts',
+    description: 'Percentage discount given to customers',
+    type: 'percentage',
+    min: 0,
+    max: 50,
+    step: 0.1,
+    defaultValue: 3
+  },
+  {
+    id: 'otherIncome',
+    label: 'Other Income',
+    description: 'Additional revenue sources (e.g., notary services, business consulting)',
+    type: 'currency',
+    min: 0,
+    max: 50000,
+    step: 100,
+    defaultValue: 0,
+    conditional: 'hasOtherIncome'
+  }
+];
+
+// Schema generation for dynamic forms
+function schemaFor(region: Region, conditions: Record<string, boolean> = {}): IncomeDriverField[] {
+  return INCOME_DRIVER_FIELDS.filter(field => {
+    // Region filtering
+    if (field.regionSpecific && field.regionSpecific !== region && field.regionSpecific !== 'both') {
+      return false;
+    }
+    
+    // Conditional filtering
+    if (field.conditional) {
+      return conditions[field.conditional] === true;
+    }
+    
+    return true;
+  });
+}
+
+interface IncomeDriverData {
+  avgNetFee: number;
+  taxPrepReturns: number;
+  taxRushReturns: number;
+  discountsPct: number;
+  otherIncome: number;
+  handlesTaxRush: boolean;
+  hasOtherIncome: boolean;
+}
+
+@Component({
+  selector: 'app-legacy-income-drivers',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  template: `
+    <div class="income-drivers-container">
+      <div class="section-header">
+        <h3>💰 Income Drivers</h3>
+        <p class="section-description">Configure your income targets and revenue sources</p>
+      </div>
+
+      <form [formGroup]="incomeForm" class="income-drivers-form">
+        <div class="fields-container">
+          <div *ngFor="let field of visibleFields; trackBy: trackByFieldId" 
+               class="field-group" 
+               [ngClass]="getFieldCssClass(field)">
+            
+            <!-- Field Label and Description -->
+            <div class="field-header">
+              <label [for]="field.id" class="field-label">
+                {{ field.label }}
+                <span *ngIf="field.description" 
+                      class="help-button" 
+                      [title]="field.description">
+                  ℹ️
+                </span>
+              </label>
+              
+              <!-- Calculated Display (for derived values) -->
+              <div *ngIf="getDerivedValue(field.id) !== null" class="derived-value">
+                {{ formatFieldValue(getDerivedValue(field.id)!, field.type) }}
+              </div>
+            </div>
+
+            <!-- Input Controls -->
+            <div class="input-controls">
+              <!-- Currency/Number Input -->
+              <div class="input-group">
+                <span *ngIf="field.type === 'currency'" class="input-prefix">$</span>
+                <span *ngIf="field.type === 'number'" class="input-prefix">#</span>
+                
+                <input
+                  [id]="field.id"
+                  [formControlName]="field.id"
+                  type="number"
+                  [min]="field.min"
+                  [max]="field.max"
+                  [step]="field.step"
+                  [placeholder]="field.defaultValue.toString()"
+                  class="field-input"
+                  [class.currency-input]="field.type === 'currency'"
+                  [class.number-input]="field.type === 'number'"
+                  [class.percentage-input]="field.type === 'percentage'">
+                
+                <span *ngIf="field.type === 'percentage'" class="input-suffix">%</span>
+              </div>
+
+              <!-- Dollar Equivalent for Percentage Fields -->
+              <div *ngIf="field.type === 'percentage' && field.id === 'discountsPct'" 
+                   class="dollar-equivalent">
+                <span class="equals-symbol">=</span>
+                <div class="input-group">
+                  <span class="input-prefix">$</span>
+                  <input
+                    type="number"
+                    [value]="getDiscountDollarAmount()"
+                    (input)="onDiscountDollarChange($event)"
+                    class="field-input dollar-input"
+                    placeholder="0">
+                </div>
+              </div>
+            </div>
+
+            <!-- Range Slider -->
+            <input *ngIf="showSliderFor(field)"
+                   type="range"
+                   [formControlName]="field.id"
+                   [min]="field.min"
+                   [max]="getSliderMax(field)"
+                   [step]="field.step"
+                   class="field-slider">
+
+            <!-- Field Description -->
+            <p *ngIf="field.description" class="field-description">
+              {{ field.description }}
+            </p>
+          </div>
+        </div>
+
+        <!-- Calculated Revenue Summary -->
+        <div class="revenue-summary" *ngIf="calculatedValues.totalRevenue > 0">
+          <div class="summary-row">
+            <span class="summary-label">Gross Tax Prep Fees:</span>
+            <span class="summary-value">{{ formatCurrency(calculatedValues.grossFees) }}</span>
+          </div>
+          <div class="summary-row">
+            <span class="summary-label">Less: Customer Discounts:</span>
+            <span class="summary-value negative">{{ formatCurrency(calculatedValues.discounts) }}</span>
+          </div>
+          <div class="summary-row">
+            <span class="summary-label">Net Tax Prep Income:</span>
+            <span class="summary-value">{{ formatCurrency(calculatedValues.taxPrepIncome) }}</span>
+          </div>
+          <div *ngIf="calculatedValues.taxRushIncome > 0" class="summary-row">
+            <span class="summary-label">TaxRush Income:</span>
+            <span class="summary-value">{{ formatCurrency(calculatedValues.taxRushIncome) }}</span>
+          </div>
+          <div *ngIf="calculatedValues.otherIncome > 0" class="summary-row">
+            <span class="summary-label">Other Income:</span>
+            <span class="summary-value">{{ formatCurrency(calculatedValues.otherIncome) }}</span>
+          </div>
+          <div class="summary-row total-row">
+            <span class="summary-label">Total Revenue:</span>
+            <span class="summary-value">{{ formatCurrency(calculatedValues.totalRevenue) }}</span>
+          </div>
+        </div>
+      </form>
+    </div>
+  `,
+  styles: [`
+    .income-drivers-container {
+      background: #fafafa;
+      border: 1px solid #d1d5db;
+      border-radius: 8px;
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .section-header h3 {
+      display: flex;
+      align-items: center;
+      margin-bottom: 0.5rem;
+      font-weight: 600;
+      font-size: 1.1rem;
+      color: #059669;
+      border-bottom: 2px solid #059669;
+      padding-bottom: 0.25rem;
+    }
+
+    .section-description {
+      color: #6b7280;
+      font-size: 0.875rem;
+      margin: 0 0 1.5rem 0;
+    }
+
+    .fields-container {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .field-group {
+      background: white;
+      border: 1px solid #e5e7eb;
+      border-radius: 6px;
+      padding: 1rem;
+    }
+
+    .field-group.taxrush-field {
+      border: 2px solid #3b82f6;
+      background-color: #f8fafc;
+    }
+
+    .field-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 0.5rem;
+    }
+
+    .field-label {
+      font-size: 0.9rem;
+      font-weight: 500;
+      color: #374151;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .help-button {
+      background: none;
+      border: none;
+      color: #6b7280;
+      cursor: help;
+      font-size: 0.8rem;
+      padding: 0;
+    }
+
+    .derived-value {
+      font-size: 0.875rem;
+      color: #059669;
+      font-weight: 500;
+      padding: 0.25rem 0.5rem;
+      background: #f0fdf4;
+      border-radius: 4px;
+    }
+
+    .input-controls {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .input-group {
+      display: flex;
+      align-items: center;
+      position: relative;
+    }
+
+    .input-prefix,
+    .input-suffix {
+      position: absolute;
+      color: #6b7280;
+      font-size: 0.8rem;
+      font-weight: 500;
+      z-index: 1;
+    }
+
+    .input-prefix {
+      left: 0.75rem;
+    }
+
+    .input-suffix {
+      right: 0.75rem;
+    }
+
+    .field-input {
+      padding: 0.5rem;
+      border: 1px solid #d1d5db;
+      border-radius: 4px;
+      font-size: 0.9rem;
+      width: 120px;
+      text-align: right;
+    }
+
+    .currency-input,
+    .number-input {
+      padding-left: 1.5rem;
+    }
+
+    .percentage-input {
+      padding-right: 1.5rem;
+    }
+
+    .field-input:focus {
+      outline: none;
+      border-color: #3b82f6;
+      box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+    }
+
+    .dollar-equivalent {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .equals-symbol {
+      color: #6b7280;
+      font-size: 0.8rem;
+    }
+
+    .dollar-input {
+      background-color: #f9fafb;
+      width: 100px;
+    }
+
+    .field-slider {
+      width: 100%;
+      margin: 0.5rem 0;
+    }
+
+    .field-description {
+      font-size: 0.75rem;
+      color: #6b7280;
+      margin: 0.25rem 0 0 0;
+      line-height: 1.4;
+    }
+
+    .revenue-summary {
+      margin-top: 1.5rem;
+      padding: 1rem;
+      background: #f0f9ff;
+      border: 1px solid #0ea5e9;
+      border-radius: 6px;
+    }
+
+    .summary-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 0.25rem 0;
+    }
+
+    .summary-label {
+      font-size: 0.875rem;
+      color: #374151;
+    }
+
+    .summary-value {
+      font-weight: 500;
+      color: #374151;
+    }
+
+    .summary-value.negative {
+      color: #dc2626;
+    }
+
+    .total-row {
+      border-top: 1px solid #0ea5e9;
+      padding-top: 0.5rem;
+      margin-top: 0.5rem;
+    }
+
+    .total-row .summary-label,
+    .total-row .summary-value {
+      font-weight: 600;
+      font-size: 1rem;
+      color: #0369a1;
+    }
+  `]
+})
+export class LegacyIncomeDriversComponent implements OnInit, OnDestroy {
+  @Input() region: Region = 'US';
+  @Input() initialData: Partial<IncomeDriverData> = {};
+  @Input() handlesTaxRush: boolean = false;
+  @Input() hasOtherIncome: boolean = false;
+
+  @Output() dataChange = new EventEmitter<IncomeDriverData>();
+  @Output() calculatedValues = new EventEmitter<any>();
+
+  incomeForm: FormGroup;
+  visibleFields: IncomeDriverField[] = [];
+  
+  // Calculated values for display (derived via calc.util pattern)
+  calculatedValues = {
+    grossFees: 0,
+    discounts: 0,
+    taxPrepIncome: 0,
+    taxRushIncome: 0,
+    otherIncome: 0,
+    totalRevenue: 0
+  };
+
+  private destroy$ = new Subject<void>();
+
+  constructor(private fb: FormBuilder) {
+    this.incomeForm = this.createForm();
+  }
+
+  ngOnInit() {
+    this.updateVisibleFields();
+    this.initializeFormValues();
+    this.setupValueChangeHandlers();
+    this.calculateDerivedValues();
+  }
+
+  ngOnDestroy() {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  private createForm(): FormGroup {
+    const formControls: Record<string, FormControl> = {};
+    
+    INCOME_DRIVER_FIELDS.forEach(field => {
+      formControls[field.id] = new FormControl(
+        this.initialData[field.id as keyof IncomeDriverData] ?? field.defaultValue
+      );
+    });
+
+    return this.fb.group(formControls);
+  }
+
+  private updateVisibleFields() {
+    const conditions = {
+      handlesTaxRush: this.handlesTaxRush,
+      hasOtherIncome: this.hasOtherIncome
+    };
+    
+    this.visibleFields = schemaFor(this.region, conditions);
+  }
+
+  private initializeFormValues() {
+    this.visibleFields.forEach(field => {
+      const currentValue = this.incomeForm.get(field.id)?.value;
+      if (currentValue === null || currentValue === undefined) {
+        this.incomeForm.get(field.id)?.setValue(field.defaultValue);
+      }
+    });
+  }
+
+  private setupValueChangeHandlers() {
+    // Debounced valueChanges for calc.util integration
+    this.incomeForm.valueChanges
+      .pipe(
+        debounceTime(300),
+        distinctUntilChanged((prev, curr) => JSON.stringify(prev) === JSON.stringify(curr)),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(values => {
+        this.calculateDerivedValues();
+        this.emitDataChange();
+      });
+  }
+
+  // Calc.util integration - derive calculated values
+  private calculateDerivedValues() {
+    const formValues = this.incomeForm.value;
+    
+    // Core calculations following calc.util pattern
+    const grossFees = (formValues.avgNetFee || 0) * (formValues.taxPrepReturns || 0);
+    const discounts = grossFees * ((formValues.discountsPct || 0) / 100);
+    const taxPrepIncome = grossFees - discounts;
+    
+    // TaxRush income (Canada only)
+    const taxRushIncome = this.region === 'CA' && this.handlesTaxRush ? 
+      (formValues.taxRushReturns || 0) * (formValues.avgNetFee || 0) * 0.15 : 0;
+    
+    const otherIncome = this.hasOtherIncome ? (formValues.otherIncome || 0) : 0;
+    const totalRevenue = taxPrepIncome + taxRushIncome + otherIncome;
+
+    // Update calculated values
+    this.calculatedValues = {
+      grossFees,
+      discounts,
+      taxPrepIncome,
+      taxRushIncome,
+      otherIncome,
+      totalRevenue
+    };
+
+    // Emit calculated values for parent components
+    this.calculatedValues.emit(this.calculatedValues);
+  }
+
+  private emitDataChange() {
+    const formData = this.incomeForm.value;
+    const data: IncomeDriverData = {
+      avgNetFee: formData.avgNetFee || 0,
+      taxPrepReturns: formData.taxPrepReturns || 0,
+      taxRushReturns: formData.taxRushReturns || 0,
+      discountsPct: formData.discountsPct || 0,
+      otherIncome: formData.otherIncome || 0,
+      handlesTaxRush: this.handlesTaxRush,
+      hasOtherIncome: this.hasOtherIncome
+    };
+
+    this.dataChange.emit(data);
+  }
+
+  // Template helper methods
+  trackByFieldId(index: number, field: IncomeDriverField): string {
+    return field.id;
+  }
+
+  getFieldCssClass(field: IncomeDriverField): string {
+    if (field.regionSpecific === 'CA' && field.id === 'taxRushReturns') {
+      return 'taxrush-field';
+    }
+    return '';
+  }
+
+  getDerivedValue(fieldId: string): number | null {
+    // Return derived/calculated values for display
+    switch (fieldId) {
+      case 'grossTaxPrepFees':
+        return this.calculatedValues.grossFees;
+      case 'netTaxPrepIncome':
+        return this.calculatedValues.taxPrepIncome;
+      default:
+        return null;
+    }
+  }
+
+  formatFieldValue(value: number, type: string): string {
+    switch (type) {
+      case 'currency':
+        return formatCurrency(value);
+      case 'percentage':
+        return formatPercentage(value);
+      default:
+        return value.toString();
+    }
+  }
+
+  showSliderFor(field: IncomeDriverField): boolean {
+    // Show sliders for main driver fields
+    return ['avgNetFee', 'taxPrepReturns', 'discountsPct'].includes(field.id);
+  }
+
+  getSliderMax(field: IncomeDriverField): number {
+    // Adjust slider max for better UX
+    switch (field.id) {
+      case 'taxPrepReturns':
+        return Math.min(field.max, 5000); // Cap slider at 5000 for better granularity
+      case 'discountsPct':
+        return Math.min(field.max, 25); // Cap discounts at 25% for slider
+      default:
+        return field.max;
+    }
+  }
+
+  getDiscountDollarAmount(): number {
+    const discountsPct = this.incomeForm.get('discountsPct')?.value || 0;
+    return this.calculatedValues.grossFees * (discountsPct / 100);
+  }
+
+  onDiscountDollarChange(event: Event) {
+    const target = event.target as HTMLInputElement;
+    const dollarAmount = parseFloat(target.value) || 0;
+    
+    if (this.calculatedValues.grossFees > 0) {
+      const newPercentage = (dollarAmount / this.calculatedValues.grossFees) * 100;
+      const cappedPercentage = Math.max(0, Math.min(50, newPercentage));
+      
+      this.incomeForm.get('discountsPct')?.setValue(cappedPercentage, { emitEvent: true });
+    }
+  }
+
+  // Expose utility functions to template
+  formatCurrency = formatCurrency;
+  formatPercentage = formatPercentage;
+}

--- a/src/app/components/prior-year-performance/prior-year-performance.component.ts
+++ b/src/app/components/prior-year-performance/prior-year-performance.component.ts
@@ -1,0 +1,42 @@
+import { Component, Input } from '@angular/core';
+
+export interface PriorYearMetrics {
+  avgNetFee?: number;
+  taxPrepReturns?: number;
+  taxRushReturns?: number;
+  taxRushPercentage?: number;
+  taxRushFee?: number;
+  grossTaxPrepFees?: number;
+  discountsPct?: number;
+  discountsAmt?: number;
+  netTaxPrepIncome?: number;
+  otherIncome?: number;
+  taxRushIncome?: number;
+  totalRevenue?: number;
+}
+
+@Component({
+  selector: 'app-prior-year-performance',
+  standalone: true,
+  template: `
+    <section class="prior-year-performance" *ngIf="metrics">
+      <h3 class="text-base font-semibold">Prior Year Summary</h3>
+      <ul class="text-sm">
+        <li *ngIf="metrics.avgNetFee !== undefined">Avg Net Fee: {{ metrics.avgNetFee | number:'1.0-0' }}</li>
+        <li *ngIf="metrics.taxPrepReturns !== undefined">Returns: {{ metrics.taxPrepReturns | number }}</li>
+        <li *ngIf="metrics.totalRevenue !== undefined">Total Revenue: {{ metrics.totalRevenue | number:'1.0-0' }}</li>
+      </ul>
+    </section>
+  `,
+  styles: [`
+    .prior-year-performance {
+      padding: 0.75rem 1rem;
+      border: 1px solid rgba(15, 23, 42, 0.08);
+      border-radius: 0.5rem;
+      background: #f8fafc;
+    }
+  `]
+})
+export class PriorYearPerformanceComponent {
+  @Input() metrics?: PriorYearMetrics;
+}

--- a/src/app/components/wizard-shell/wizard-shell.component.html
+++ b/src/app/components/wizard-shell/wizard-shell.component.html
@@ -115,14 +115,14 @@
 
     <!-- Income Drivers Component (Existing Store only) -->
     <div *ngIf="answers.storeType === 'existing'">
-      <app-income-drivers
+      <app-legacy-income-drivers
         [region]="answers.region"
         [handlesTaxRush]="answers.handlesTaxRush || false"
         [hasOtherIncome]="answers.hasOtherIncome || false"
         [initialData]="getIncomeDriverData()"
         (dataChange)="onIncomeDriverChange($event)"
         (calculatedValues)="onIncomeCalculatedValues($event)">
-      </app-income-drivers>
+      </app-legacy-income-drivers>
     </div>
 
     <!-- Target Performance Goals Section (New Store only) -->

--- a/src/app/components/wizard-shell/wizard-shell.component.ts
+++ b/src/app/components/wizard-shell/wizard-shell.component.ts
@@ -3,12 +3,12 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Region, WizardAnswers, WizardStep } from '../../models/wizard.models';
 import { PersistenceService } from '../../services/persistence.service';
-import { IncomeDriversComponent } from '../income-drivers/income-drivers.component';
+import { LegacyIncomeDriversComponent } from '../income-drivers/legacy-income-drivers.component';
 
 @Component({
   selector: 'app-wizard-shell',
   standalone: true,
-  imports: [CommonModule, FormsModule, IncomeDriversComponent],
+  imports: [CommonModule, FormsModule, LegacyIncomeDriversComponent],
   templateUrl: './wizard-shell.component.html',
   styleUrls: ['./wizard-shell.component.scss']
 })

--- a/src/app/existing-store/income-drivers/goals.config.ts
+++ b/src/app/existing-store/income-drivers/goals.config.ts
@@ -1,0 +1,45 @@
+import type { FieldKey } from '../shared/fields.dictionary';
+
+export type Mode = 'new' | 'existing';
+
+export interface GoalsSchemaEntry {
+  id: string;
+  fields: FieldKey[];
+}
+
+const BASE_FIELDS: FieldKey[] = [
+  'avgNetFee',
+  'taxPrepReturns',
+  'grossTaxPrepFees',
+  'discountsPct',
+  'discountsAmt',
+  'netTaxPrepIncome',
+  'otherIncome',
+  'totalRevenue'
+];
+
+const TAXRUSH_FIELDS: FieldKey[] = [
+  'taxRushReturns',
+  'taxRushPercentage',
+  'taxRushFee',
+  'taxRushIncome'
+];
+
+export function schemaFor(mode: Mode, region: string, storeType: string): GoalsSchemaEntry {
+  const fields: FieldKey[] = [...BASE_FIELDS];
+
+  if (region === 'CA') {
+    const insertIndex = fields.indexOf('grossTaxPrepFees');
+    const before = insertIndex >= 0 ? fields.slice(0, insertIndex) : fields.slice();
+    const after = insertIndex >= 0 ? fields.slice(insertIndex) : [];
+    const ordered = [...before, ...TAXRUSH_FIELDS, ...after];
+    fields.splice(0, fields.length, ...ordered);
+  }
+
+  const id = `${mode}-${region}-${storeType}`;
+
+  return {
+    id,
+    fields
+  };
+}

--- a/src/app/existing-store/shared/calc.util.ts
+++ b/src/app/existing-store/shared/calc.util.ts
@@ -1,0 +1,102 @@
+export interface GrossFeeOptions {
+  region?: string;
+  handlesTaxRush?: boolean;
+}
+
+function asNumber(value: unknown): number | null {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+  const num = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+export function calculateGrossTaxPrepFees(
+  avgNetFee: unknown,
+  taxPrepReturns: unknown,
+  taxRushReturns: unknown,
+  options: GrossFeeOptions = {}
+): number | null {
+  const anf = asNumber(avgNetFee);
+  const returns = asNumber(taxPrepReturns);
+  const rushReturns = asNumber(taxRushReturns) ?? 0;
+
+  if (anf === null || returns === null) {
+    return null;
+  }
+
+  if (options.region === 'CA' && options.handlesTaxRush) {
+    const netReturns = Math.max(returns - rushReturns, 0);
+    return Math.round(netReturns * anf);
+  }
+
+  return Math.round(anf * returns);
+}
+
+export function calculateDiscountAmount(grossFees: unknown, discountsPct: unknown): number | null {
+  const gross = asNumber(grossFees);
+  const pct = asNumber(discountsPct);
+
+  if (gross === null || pct === null) {
+    return null;
+  }
+
+  return Math.round(gross * (pct / 100));
+}
+
+export function calculateNetTaxPrepIncome(grossFees: unknown, discountAmount: unknown): number | null {
+  const gross = asNumber(grossFees);
+  const discount = asNumber(discountAmount) ?? 0;
+
+  if (gross === null) {
+    return null;
+  }
+
+  return Math.round(gross - discount);
+}
+
+export function calculateTaxRushReturns(taxPrepReturns: unknown, taxRushPercentage: unknown): number | null {
+  const returns = asNumber(taxPrepReturns);
+  const pct = asNumber(taxRushPercentage);
+
+  if (returns === null || pct === null) {
+    return null;
+  }
+
+  return Math.round(returns * (pct / 100));
+}
+
+export function calculateTaxRushPercentage(taxPrepReturns: unknown, taxRushReturns: unknown): number | null {
+  const returns = asNumber(taxPrepReturns);
+  const rush = asNumber(taxRushReturns);
+
+  if (returns === null || returns === 0 || rush === null) {
+    return null;
+  }
+
+  return Math.round((rush / returns) * 1000) / 10;
+}
+
+export function calculateTaxRushIncome(taxRushReturns: unknown, taxRushFee: unknown): number | null {
+  const rushReturns = asNumber(taxRushReturns);
+  const rushFee = asNumber(taxRushFee);
+
+  if (rushReturns === null || rushFee === null) {
+    return null;
+  }
+
+  return Math.round(rushReturns * rushFee);
+}
+
+export function calculateTotalRevenue(
+  netTaxPrepIncome: unknown,
+  taxRushIncome: unknown,
+  otherIncome: unknown
+): number | null {
+  const netIncome = asNumber(netTaxPrepIncome) ?? 0;
+  const rushIncome = asNumber(taxRushIncome) ?? 0;
+  const other = asNumber(otherIncome) ?? 0;
+
+  const sum = netIncome + rushIncome + other;
+  return Number.isFinite(sum) ? Math.round(sum) : null;
+}

--- a/src/app/existing-store/shared/fields.dictionary.ts
+++ b/src/app/existing-store/shared/fields.dictionary.ts
@@ -1,0 +1,104 @@
+export type FieldType = 'number' | 'money' | 'percent' | 'text';
+
+export interface FieldValidators {
+  required?: boolean;
+  min?: number;
+  max?: number;
+  pattern?: RegExp | string;
+}
+
+export interface FieldSpec {
+  label: string;
+  type: FieldType;
+  unit?: string;
+  help?: string;
+  deriveFrom?: FieldKey[];
+  validators?: FieldValidators;
+}
+
+export const FIELDS = {
+  avgNetFee: {
+    label: 'Average Net Fee',
+    type: 'money',
+    unit: 'USD',
+    help: 'Average net fee you expect to collect per return',
+    validators: { required: true, min: 0 }
+  },
+  taxPrepReturns: {
+    label: 'Tax Prep Returns',
+    type: 'number',
+    unit: 'returns',
+    help: 'Number of tax preparation returns you expect to complete',
+    validators: { required: true, min: 0 }
+  },
+  grossTaxPrepFees: {
+    label: 'Gross Tax Prep Fees',
+    type: 'money',
+    unit: 'USD',
+    help: 'Automatically calculated as Average Net Fee × Tax Prep Returns',
+    deriveFrom: ['avgNetFee', 'taxPrepReturns', 'taxRushReturns']
+  },
+  discountsPct: {
+    label: 'Customer Discounts %',
+    type: 'percent',
+    unit: '%',
+    help: 'Average discount percentage applied to customers',
+    validators: { required: true, min: 0, max: 100 }
+  },
+  discountsAmt: {
+    label: 'Customer Discounts ($)',
+    type: 'money',
+    unit: 'USD',
+    help: 'Automatically calculated from gross fees and discount percentage',
+    deriveFrom: ['grossTaxPrepFees', 'discountsPct']
+  },
+  netTaxPrepIncome: {
+    label: 'Net Tax Prep Income',
+    type: 'money',
+    unit: 'USD',
+    help: 'Gross tax prep fees minus customer discounts',
+    deriveFrom: ['grossTaxPrepFees', 'discountsAmt']
+  },
+  taxRushReturns: {
+    label: 'TaxRush Returns',
+    type: 'number',
+    unit: 'returns',
+    help: 'Total number of TaxRush returns (Canada only)'
+  },
+  taxRushPercentage: {
+    label: 'TaxRush % of Returns',
+    type: 'percent',
+    unit: '%',
+    help: 'Percentage of returns that are TaxRush services',
+    deriveFrom: ['taxPrepReturns', 'taxRushReturns']
+  },
+  taxRushFee: {
+    label: 'TaxRush Average Net Fee',
+    type: 'money',
+    unit: 'USD',
+    help: 'Average net fee collected per TaxRush return'
+  },
+  taxRushIncome: {
+    label: 'TaxRush Income',
+    type: 'money',
+    unit: 'USD',
+    help: 'Calculated as TaxRush Returns × TaxRush Average Net Fee',
+    deriveFrom: ['taxRushReturns', 'taxRushFee']
+  },
+  otherIncome: {
+    label: 'Other Income',
+    type: 'money',
+    unit: 'USD',
+    help: 'Additional revenue from services beyond tax preparation',
+    validators: { min: 0 }
+  },
+  totalRevenue: {
+    label: 'Total Revenue',
+    type: 'money',
+    unit: 'USD',
+    help: 'Net tax prep income plus TaxRush income and other income',
+    deriveFrom: ['netTaxPrepIncome', 'taxRushIncome', 'otherIncome']
+  }
+} as const satisfies Record<string, FieldSpec>;
+
+export type FieldKey = keyof typeof FIELDS;


### PR DESCRIPTION
## Summary
- add a new schema-driven IncomeDriversComponent that builds its reactive form from reusable field metadata and calculates derived values
- preserve the existing wizard implementation by moving the previous income drivers UI to a LegacyIncomeDriversComponent and updating the wizard shell to reference it
- introduce shared income driver configuration, calculation utilities, and a minimal prior-year performance component to seed form defaults

## Testing
- npm test -- --watch=false *(fails: ng not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8af97bfe48327929c62c47fd2910b